### PR TITLE
History editing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,9 +486,9 @@ Lair's chat interface provides several ways to view and modify chat history, mak
 
 The chat history can be viewed in different formats. The `/history` command presents the chat in a formatted, readable manner, which may include markdown rendering, reasoning model formatting, and truncation, depending on configuration. For a raw data view, the `/messages` command displays the chat history as a JSONL-formatted list of message objects.
 
-To remove specific messages from the history, use the `/history-slice` command. This command accepts Python-style slicing syntax:
+To remove specific messages from the history, use the `/history-slice` command. This command accepts Python-style slicing syntax (`start:stop:step`). Each section is optional. Start defaults to `0`, stop to the end of the sequence, and step to `1`. For example:
 
-- `:4` retains only the first four messages.
+- `:4` retains only the first four messages. This is equivalent to `0:4:1`.
 - `:-2` removes the last two messages while keeping the rest.
 - `::2` keeps every other message, starting with the first.
 
@@ -504,7 +504,7 @@ crocodile> /messages
 {"role": "assistant", "content": "I would pick Botty McBotface."}
 ```
 
-Applying `/history-slice :-2` removes the last two messages:
+Using `/history-slice` :-2 removes the last two messages. The slice `:-2` is a shorthand for `0:-2:1`, meaning it starts from the first element, stops at the second-to-last, and moves one step at a time.
 
 ```
 crocodile> /history-slice :-2

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Modules: [Chat](#chat---command-line-chat-interface) |
         - [Search Tool](#search-tool)
       - [One-off Chat](#one-off-chat)
       - [Extracting Embedded Responses](#extracting-embedded-responses)
+      - [Modifying Chat History](#modifying-chat-history)
     - [Model Settings](#model-settings)
     - [Session Management](#session-management)
     - [Calling Comfy Workflows](#calling-comfy-workflows)
@@ -185,25 +186,27 @@ When Verbose output is enabled tool calls and responses are displayed.
 
 #### Commands
 
-| Command          | Description                                                                                               |
-|------------------|-----------------------------------------------------------------------------------------------------------|
-| /clear           | Clear the conversation history                                                                            |
-| /comfy           | Call ComfyUI workflows                                                                                    |
-| /debug           | Toggle debugging                                                                                          |
-| /extract         | Display or save an embedded response  (usage: `/extract [position?] [filename?]`)                         |
-| /help            | Show available commands and shortcuts                                                                     |
-| /history         | Show current conversation                                                                                 |
-| /last-prompt     | Display or save the most recently used prompt  (usage: /last-prompt [filename?])                          |
-| /last-response   | Display or save the most recently seen response  (usage: /last-response [filename?])                      |
-| /list-models     | Display a list of available models for the current session                                                |
-| /messages        | Display or save the JSON message history as JSONL (usage: `/messages [filename?]`)                        |
-| /load            | Load a session from a file  (usage: `/load [filename?]`, default filename is `chat_session.json`)         |
-| /mode            | Show or select a mode  (usage: `/mode [name?]`)                                                           |
-| /model           | Show or set a model  (usage: `/model [name?]`)                                                            |
-| /prompt          | Show or set the system prompt  (usage: `/prompt [prompt?]`)                                               |
-| /reload-settings | Reload settings from disk  (resets everything, except current mode)                                       |
-| /save            | Save the current session to a file  (usage: `/save [filename?]`, default filename is `chat_session.json`) |
-| /set             | Show configuration or set a configuration value for the current mode  (usage: `/set ([key?] [value?])?`)  |
+| Command          | Description                                                                                                            |
+|------------------|------------------------------------------------------------------------------------------------------------------------|
+| /clear           | Clear the conversation history                                                                                         |
+| /comfy           | Call ComfyUI workflows                                                                                                 |
+| /debug           | Toggle debugging                                                                                                       |
+| /extract         | Display or save an embedded response  (usage: `/extract [position?] [filename?]`)                                      |
+| /help            | Show available commands and shortcuts                                                                                  |
+| /history         | Show current conversation                                                                                              |
+| /history-edit    | Modify the history JSONL in an external editor                                                                         |
+| /history-slice   | Modify the history with a Python style slice string (usage: `/history-slice [slice]`, slice format: `start:stop:step`) |
+| /last-prompt     | Display or save the most recently used prompt  (usage: `/last-prompt [filename?]`)                                     |
+| /last-response   | Display or save the most recently seen response  (usage: `/last-response [filename?]`)                                 |
+| /list-models     | Display a list of available models for the current session                                                             |
+| /messages        | Display or save the JSON message history as JSONL (usage: `/messages [filename?]`)                                     |
+| /load            | Load a session from a file  (usage: `/load [filename?]`, default filename is `chat_session.json`)                      |
+| /mode            | Show or select a mode  (usage: `/mode [name?]`)                                                                        |
+| /model           | Show or set a model  (usage: `/model [name?]`)                                                                         |
+| /prompt          | Show or set the system prompt  (usage: `/prompt [prompt?]`)                                                            |
+| /reload-settings | Reload settings from disk  (resets everything, except current mode)                                                    |
+| /save            | Save the current session to a file  (usage: `/save [filename?]`, default filename is `chat_session.json`)              |
+| /set             | Show configuration or set a configuration value for the current mode  (usage: `/set ([key?] [value?])?`)               |
 
 #### Shortcut Keys
 
@@ -476,6 +479,48 @@ A second argument can specify a filename as a destination for writing out the se
 crocodile> /extract 0 ~/hello.go
 Response saved  (76 bytes)
 ```
+
+##### Modifying Chat History
+
+Lair's chat interface provides several ways to view and modify chat history, making it easier to refine past interactions.
+
+The chat history can be viewed in different formats. The `/history` command presents the chat in a formatted, readable manner, which may include markdown rendering, reasoning model formatting, and truncation, depending on configuration. For a raw data view, the `/messages` command displays the chat history as a JSONL-formatted list of message objects.
+
+To remove specific messages from the history, use the `/history-slice` command. This command accepts Python-style slicing syntax:
+
+- `:4` retains only the first four messages.
+- `:-2` removes the last two messages while keeping the rest.
+- `::2` keeps every other message, starting with the first.
+
+For example, consider the following chat history:
+
+```
+crocodile> /messages
+{"role": "user", "content": "Hi"}
+{"role": "assistant", "content": "Hello there."}
+{"role": "user", "content": "What is your name?"}
+{"role": "assistant", "content": "My name is ChatBot."}
+{"role": "user", "content": "If you could pick a new name, what would it be?"}
+{"role": "assistant", "content": "I would pick Botty McBotface."}
+```
+
+Applying `/history-slice :-2` removes the last two messages:
+
+```
+crocodile> /history-slice :-2
+History updated (Selected 4 messages out of 6)
+crocodile> /messages
+{"role": "user", "content": "Hi"}
+{"role": "assistant", "content": "Hello there."}
+{"role": "user", "content": "What is your name?"}
+{"role": "assistant", "content": "My name is ChatBot."}
+```
+
+For more advanced modifications, the `/history-edit` command allows editing the chat history in an external text editor. The editor used is determined by `misc.editor_command`, or, if not set, the `VISUAL` or `EDITOR` environment variables.
+
+When `/history-edit` is executed, the full chat history is loaded into a JSONL-formatted file where each line represents a message object following the OpenAI API format. This allows users to add or remove messages, as well as modifying any message content, including assistant responses
+
+Since `/history-edit` loads the complete history without truncation, large files may result if attachments or tool calls are present.
 
 #### Model Settings
 

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -1,4 +1,7 @@
+import json
+
 import lair
+import lair.components.history.schema
 from lair.logging import logger
 
 
@@ -59,6 +62,9 @@ class ChatHistory():
         for message in messages:
             self.add_message(message['role'], message['content'])
 
+    def num_messages(self):
+        return len(self._history)
+
     def get_messages(self, *, extra_messages=None):
         """
         Return the message history, truncating as necessary
@@ -70,8 +76,14 @@ class ChatHistory():
         else:
             return self._history[-max_length:] + extra_messages
 
+    def get_messages_as_jsonl_string(self):
+        messages = self.get_messages()
+        return "\n".join(json.dumps(message) for message in messages)
+
     def set_history(self, messages):
         '''Replace history with the provided messages'''
+        lair.components.history.schema.validate_messages(messages)
+
         self._history = messages
         self._truncate()
         self.finalized_index = len(self._history)

--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -1,0 +1,107 @@
+import jsonschema
+
+
+MESSAGES_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant", "tool"]
+            },
+            "content": {
+                "type": ["string", "null"],
+                "description": "The primary text content of the message. Null if tool call or file attachment is present."
+            },
+            "tool_calls": {
+                "type": ["array", "null"],
+                "description": "List of tools called by the assistant.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "Unique identifier for the tool call."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The tool's name being invoked."
+                        },
+                        "arguments": {
+                            "type": "object",
+                            "description": "Arguments passed to the tool.",
+                            "additionalProperties": True
+                        }
+                    },
+                    "required": ["id", "name", "arguments"]
+                }
+            },
+            "refusal": {
+                "type": ["string", "null"],
+                "description": "A message explaining why the assistant refused to respond."
+            },
+            "file_attachments": {
+                "type": ["array", "null"],
+                "description": "List of file attachments included in the message.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "Unique identifier for the attached file."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Original filename."
+                        },
+                        "mime_type": {
+                            "type": "string",
+                            "description": "MIME type of the file."
+                        },
+                        "size": {
+                            "type": "integer",
+                            "description": "Size of the file in bytes."
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A URL where the file can be accessed (if applicable)."
+                        }
+                    },
+                    "required": ["id", "name", "mime_type", "size"]
+                }
+            }
+        },
+        "required": ["role"],
+        "anyOf": [
+            {"required": ["content"]},
+            {"required": ["tool_calls"]},
+            {"required": ["refusal"]},
+            {"required": ["file_attachments"]}
+        ]
+    }
+}
+
+
+def validate_messages(messages):
+    """
+    Validate a list of messages
+    Raise an exception if it is invalid
+    """
+    try:
+        jsonschema.validate(instance=messages, schema=MESSAGES_SCHEMA)
+    except jsonschema.exceptions.ValidationError as error:
+        # ValidationErrors when stringified return the entire schema
+        # This rewrites the error message to only be the error and adds in a path
+        if error.path:
+            path_list = list(error.path)  # Convert to a list explicitly
+            error_location = f"[{path_list[0]}]"
+
+            if len(path_list) > 1:
+                error_location += "." + ".".join(str(p) for p in path_list[1:])
+        else:
+            error_location = "root"
+
+        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}")

--- a/lair/files/settings.yaml
+++ b/lair/files/settings.yaml
@@ -175,6 +175,9 @@ database.port_environment_variable: 'DB_PORT'
 database.user: 'lair'
 database.user_environment_variable: 'DB_USER'
 
+# Which editor to use when opening an external editor. When null, this defaults to the VISUAL or
+# EDITOR environment variables or `vi` if they aren't set.
+misc.editor_command: __null_str
 # When enabled and attachments are used, the filenames are provided to the model.
 misc.provide_attachment_filenames: false
 # Maximum size for text attachments in bytes (including PDF that are converted to text)

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -248,8 +248,8 @@ def decode_jsonl(jsonl_str):
     return records
 
 
-def slice_from_str(arr, slice_str: str):
-    """Apply a user-defined slice string (e.g., ':2', '-2:', '1:4:2') to an array."""
+def slice_from_str(original_list, slice_str: str):
+    """Apply a slice string (e.g., ':2', '-2:', '1:4:2') to a list and return the new list."""
     parts = slice_str.split(':')
 
     def safe_int(value):
@@ -261,4 +261,4 @@ def slice_from_str(arr, slice_str: str):
     stop = safe_int(parts[1]) if len(parts) > 1 and parts[1] else None
     step = safe_int(parts[2]) if len(parts) > 2 and parts[2] else None
 
-    return arr[slice(start, stop, step)]
+    return original_list[slice(start, stop, step)]


### PR DESCRIPTION
## Overview

In order to make it easier to modify history, this change adds two new commands to the chat interface:  `/history-slice` and `/history-edit`

The `/history-slice` command takes Python-style slices of the current history in the `start:stop:step` format.  For example, `/history-slice :-2` removes the last two messages.

The `/history-edit` command opens an external editor (from either `misc.editor_command`, or environment variables `VISUAL` or `EDITOR`) with the raw JSONL messages, allowing history to be fully rewritten, messages removed, added, or modified.  Any field can be modified, including attachments and assistant responses.

## TODO

- [x] Fix schema for image attachments
- [x] Fix schema for tools