### PR TITLE
Add pytest suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ libtmux = "^0.46.0"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"
+pytest = "^8.1.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_argparse_utils.py
+++ b/tests/test_argparse_utils.py
@@ -1,0 +1,20 @@
+import argparse
+import pytest
+from lair.util.argparse import (
+    ErrorRaisingArgumentParser,
+    ArgumentParserExitException,
+    ArgumentParserHelpException,
+)
+
+
+def test_required_argument_error():
+    parser = ErrorRaisingArgumentParser()
+    parser.add_argument('--foo', required=True)
+    with pytest.raises(argparse.ArgumentError):
+        parser.parse_args([])
+
+
+def test_print_help_exception():
+    parser = ErrorRaisingArgumentParser()
+    with pytest.raises(ArgumentParserHelpException):
+        parser.print_help()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+import sys
+import subprocess
+
+
+def run_command(*args):
+    cmd = [sys.executable, '-c', 'import lair.cli.run as run; run.start()']
+    cmd.extend(args)
+    return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+
+def test_help_command():
+    result = run_command('--help')
+    assert 'usage:' in result.stdout.lower()
+    assert result.returncode == 0
+
+
+def test_chat_help():
+    result = run_command('chat', '--help')
+    assert 'allow-create-session' in result.stdout.lower()
+    assert result.returncode == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,29 @@
+import os
+import lair.util.core as core
+
+
+def test_safe_int():
+    assert core.safe_int('5') == 5
+    assert core.safe_int('abc') == 'abc'
+
+
+def test_decode_jsonl():
+    jsonl = '{"a":1}\n{"b":2}\n'
+    assert core.decode_jsonl(jsonl) == [{"a": 1}, {"b": 2}]
+
+
+def test_slice_from_str():
+    data = [0, 1, 2, 3, 4, 5]
+    assert core.slice_from_str(data, ':2') == [0, 1]
+    assert core.slice_from_str(data, '1:4:2') == [1, 3]
+    assert core.slice_from_str(data, '-2:') == [4, 5]
+
+
+def test_expand_filename_list(tmp_path):
+    f1 = tmp_path / 'one.txt'
+    f2 = tmp_path / 'two.txt'
+    f1.write_text('a')
+    f2.write_text('b')
+    pattern = str(tmp_path / '*.txt')
+    result = core.expand_filename_list([pattern])
+    assert str(f1) in result and str(f2) in result

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,29 @@
+from lair import events
+
+
+def test_subscribe_and_fire():
+    called = []
+
+    def handler(data):
+        called.append(data)
+
+    sub_id = events.subscribe('unit', handler)
+    events.fire('unit', {'value': 1})
+    events.unsubscribe(sub_id)
+
+    assert called == [{'value': 1}]
+
+
+def test_defer_events():
+    called = []
+
+    def handler(data):
+        called.append(data)
+
+    sub_id = events.subscribe('defer', handler)
+    with events.defer_events():
+        events.fire('defer', {'v': 1})
+        events.fire('defer', {'v': 1})  # should be squashed
+    events.unsubscribe(sub_id)
+
+    assert called == [{'v': 1}]


### PR DESCRIPTION
## Summary
- add pytest dev dependency
- add unit tests for core utilities
- add unit tests for custom argparse helpers
- add unit tests for events subsystem
- add integration tests that invoke CLI help

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f96d74cf483209600a2d372aaa7cc