### PR TITLE
Add command coverage tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - docker: Add lair into youtube image
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example
+- tests: Add coverage for all chat sub-commands
 
 # v0.8.1 - Bug fixes
 

--- a/tests/test_chat_commands.py
+++ b/tests/test_chat_commands.py
@@ -1,0 +1,83 @@
+import argparse
+import pytest
+from tests.test_chat_interface_extended import make_interface
+import lair
+
+
+# Helpers
+
+def setup_ci(monkeypatch):
+    ci = make_interface(monkeypatch)
+    monkeypatch.setattr(lair.util, 'save_file', lambda *a, **k: None)
+    monkeypatch.setattr(lair.util, 'edit_content_in_editor', lambda *a, **k: '[{"role":"user","content":"x"}]\n')
+    monkeypatch.setattr(lair.util, 'decode_jsonl', lambda s: [{'role': 'user', 'content': 'x'}])
+    monkeypatch.setattr(ci.chat_session, 'load_from_file', lambda *a, **k: None)
+    monkeypatch.setattr(ci.chat_session, 'save_to_file', lambda *a, **k: None)
+    monkeypatch.setattr(ci.chat_session.tool_set, 'get_all_tools', lambda: [])
+    monkeypatch.setattr(ci, 'print_tools_report', lambda *a, **k: None)
+    monkeypatch.setattr(ci, 'print_models_report', lambda *a, **k: None)
+    monkeypatch.setattr(ci, 'print_config_report', lambda *a, **k: None)
+    monkeypatch.setattr(ci, 'print_history', lambda *a, **k: None)
+    monkeypatch.setattr(ci, 'print_help', lambda *a, **k: None)
+    monkeypatch.setattr(ci, '_rebuild_chat_session', lambda *a, **k: None)
+    orig_get = ci.session_manager.get_session_id
+    def patched_get(id_or_alias, raise_exception=True):
+        try:
+            return orig_get(id_or_alias, raise_exception)
+        except Exception:
+            if raise_exception:
+                raise lair.sessions.session_manager.UnknownSessionException('Unknown')
+            return None
+    monkeypatch.setattr(ci.session_manager, 'get_session_id', patched_get)
+    return ci
+
+
+COMMANDS = [
+    ('clear', [], ['extra']),
+    ('debug', [], ['extra']),
+    ('extract', [], ['1', 'f', 'x']),
+    ('help', [], ['a']),
+    ('history', [], ['a']),
+    ('history_edit', [], ['a']),
+    ('history_slice', ['1:'], []),
+    ('last_prompt', [], ['a', 'b']),
+    ('last_response', [], ['a', 'b']),
+    ('list_models', [], ['a']),
+    ('list_settings', [], ['--bad']),
+    ('list_tools', [], ['a']),
+    ('load', [], None),
+    ('messages', [], ['file1', 'file2']),
+    ('mode', ['openai'], ['a', 'b']),
+    ('model', ['m'], ['a', 'b']),
+    ('prompt', [], None),
+    ('reload_settings', [], ['a']),
+    ('save', [], None),
+    ('session', [], ['a', 'b']),
+    ('session_alias', ['1', 'alias'], ['1', 'alias', 'x']),
+    ('session_delete', ['1'], []),
+    ('session_new', [], ['x']),
+    ('session_title', ['1', 'title'], []),
+    ('set', ['style.word_wrap', 'false'], ['bad.key', 'val']),
+]
+
+
+@pytest.mark.parametrize('name,valid_args,invalid_args', COMMANDS)
+def test_chat_commands(monkeypatch, name, valid_args, invalid_args):
+    ci = setup_ci(monkeypatch)
+    if name in {'extract', 'last_prompt', 'last_response'}:
+        ci.chat_session.last_response = '<answer>(data)</answer>'
+        ci.chat_session.last_prompt = 'prompt'
+    method = getattr(ci, f'command_{name}')
+
+    ci.reporting.messages.clear()
+    method('/' + name.replace('_', '-'), valid_args, ' '.join(valid_args))
+    assert not any(m[0] == 'error' for m in ci.reporting.messages)
+
+    if invalid_args is not None:
+        ci.reporting.messages.clear()
+        if name == 'list_settings':
+            with pytest.raises(argparse.ArgumentError):
+                method('/' + name.replace('_', '-'), invalid_args, ' '.join(invalid_args))
+        else:
+            method('/' + name.replace('_', '-'), invalid_args, ' '.join(invalid_args))
+            assert any(m[0] == 'error' for m in ci.reporting.messages)

--- a/tests/test_chat_interface_extended.py
+++ b/tests/test_chat_interface_extended.py
@@ -2,7 +2,7 @@ import sys
 import types
 import importlib
 
-import pytest
+import pytest  # noqa: F401
 
 
 def make_interface(monkeypatch):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-import os
 import lair.util.core as core
 
 


### PR DESCRIPTION
## Summary
- add parameterized tests for every chat sub-command
- remove unused imports flagged by ruff
- note new tests in CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411c71e060832081ce58d42d83a8b9