### PR TITLE
Improve test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example
 - tests: Add coverage for all chat sub-commands
+- tests: Add completer, attachment, and argument parsing coverage
 
 # v0.8.1 - Bug fixes
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -67,3 +67,11 @@ def test_set_config_from_arguments(monkeypatch):
 def test_set_config_from_arguments_bad(monkeypatch):
     with pytest.raises(SystemExit):
         run.set_config_from_arguments(['invalid'])
+
+def test_parse_arguments_no_subcommand(monkeypatch):
+    monkeypatch.setattr(run, 'init_subcommands', fake_init)
+    argv = ['prog']
+    with pytest.raises(SystemExit) as exc:
+        with mock.patch.object(sys, 'argv', argv):
+            run.parse_arguments()
+    assert exc.value.code == 1

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1,0 +1,57 @@
+import base64
+from prompt_toolkit.document import Document
+import lair
+from lair.cli.chat_interface_completer import ChatInterfaceCompleter
+from tests.test_chat_interface_extended import make_interface
+import lair.util.core as core
+
+
+def test_get_embedded_response(monkeypatch):
+    ci = make_interface(monkeypatch)
+    message = "<answer>(foo)</answer> \n```txt\nbar\n```"
+    assert ci._get_embedded_response(message, 0) == "foo"
+    assert ci._get_embedded_response(message, 1) == "bar"
+    assert ci._get_embedded_response(message, -1) == "bar"
+    assert ci._get_embedded_response(message, 2) is None
+
+
+def test_completer(monkeypatch):
+    ci = make_interface(monkeypatch)
+    lair.config.set('session.system_prompt_template', 'prompt text')
+    ci._models = [{'id': 'alpha'}, {'id': 'beta'}]
+    completer = ChatInterfaceCompleter(ci)
+
+    doc = Document('/mode o', cursor_position=len('/mode o'))
+    results = [c.text for c in completer.get_completions(doc, None)]
+    assert '/mode openai' in results
+    assert '/mode openai_local' in results
+
+    doc = Document('/model a', cursor_position=len('/model a'))
+    results = [c.text for c in completer.get_completions(doc, None)]
+    assert '/model alpha' in results
+
+    doc = Document('/prompt p', cursor_position=len('/prompt p'))
+    results = [c.text for c in completer.get_completions(doc, None)]
+    assert '/prompt prompt text' in results
+
+    doc = Document('/set chat.multiline_input ', cursor_position=len('/set chat.multiline_input '))
+    results = [c.text for c in completer.get_completions(doc, None)]
+    assert any(r.startswith('/set chat.multiline_input') for r in results)
+
+    doc = Document('/hist', cursor_position=len('/hist'))
+    results = [c.text for c in completer.get_completions(doc, None)]
+    assert '/history' in results
+
+
+def test_get_attachments_content(monkeypatch, tmp_path):
+    text_file = tmp_path / 'a.txt'
+    text_file.write_text('hello')
+    img_file = tmp_path / 'img.png'
+    img_file.write_bytes(base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+kBlcAAAAASUVORK5CYII='))
+    pdf_file = tmp_path / 'a.pdf'
+    pdf_file.write_text('dummy')
+    monkeypatch.setattr(core, 'read_pdf', lambda *a, **k: 'pdfdata')
+    parts, messages = core.get_attachments_content([str(img_file), str(pdf_file), str(text_file)])
+    assert any(p['type'] == 'image_url' for p in parts)
+    joined = ' '.join(m['content'] for m in messages)
+    assert 'pdfdata' in joined and 'hello' in joined


### PR DESCRIPTION
## Summary
- expand CLI argument parsing tests
- add completer and attachment coverage
- document new tests in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df9a51a0832080687582c7f352fd