### PR TITLE
Update AGENTS docs for poetry setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,16 @@ This repository contains the `lair` Python package. Before submitting any pull r
 2. `ruff lair`
 3. `pytest`
 
+Before running these checks for the first time, install the project's dependencies using Poetry:
+
+```sh
+eval $(poetry env activate)
+poetry install --with dev
+```
+
+These commands create a virtual environment, install `lair` into the path, and fetch all development dependencies so the
+tools above work correctly.
+
 Every pull request must update `CHANGELOG.md` with a short summary of its changes. New entries should be added under the top `# WIP -` heading.
 
 The first command verifies that all Python files compile. The second performs a static analysis pass for common issues. Warnings about unused imports from `__init__` files may be ignored, but new warnings should be investigated. The third command runs the test suite. It MUST pass.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - documentation: Expand README outpainting example
 - tests: Add coverage for all chat sub-commands
 - tests: Add completer, attachment, and argument parsing coverage
+- documentation: Update AGENTS instructions to use Poetry
 
 # v0.8.1 - Bug fixes
 


### PR DESCRIPTION
## Summary
- add instructions in AGENTS.md for activating a Poetry env and installing dev deps
- document the Poetry setup in CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684361d402588320a90803f75acc579f