### PR TITLE
Fix pdfplumber stub in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 - documentation: Add AGENTS.md and introduction video link
 - tests: Add pytest suite and extended chat interface coverage
+- tests: Add stub for `pdfplumber.open` to avoid AttributeError in CI
 - tests: Enable coverage and add new utility tests
 - docker: Add lair into youtube image
 - deps: Replace pyflakes with ruff for linting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,8 @@ for name in modules_to_stub:
     module = sys.modules.setdefault(name, types.ModuleType(name))
     if name == "duckduckgo_search":
         module.DDGS = object
+    elif name == "pdfplumber":
+        # pdfplumber is only used in tests and may not be installed. Provide a
+        # minimal stub so monkeypatching works without raising AttributeError.
+        module.open = lambda *args, **kwargs: None
 


### PR DESCRIPTION
## Summary
- fix pdfplumber stub so monkeypatching works
- document pdfplumber stub in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685230ceaf908320ae65c65a2f6d5e9d