### PR TITLE
Improve search tool coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example
 - tests: Add coverage for all chat sub-commands
+- tests: Add search tool coverage
 - tests: Add extra coverage for chat interface commands
 - tests: Add completer, attachment, and argument parsing coverage
 - tests: Increase coverage for cli.run module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,6 @@ for name in modules_to_stub:
     module = sys.modules.setdefault(name, types.ModuleType(name))
     if name == "duckduckgo_search":
         module.DDGS = object
+    elif name == "pdfplumber":
+        module.open = lambda *a, **k: None
 

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,0 +1,139 @@
+import lair
+import pytest
+
+from lair.components.tools.search_tool import SearchTool
+
+class DummyResponse:
+    def __init__(self, text):
+        self.text = text
+        self.called = False
+    def raise_for_status(self):
+        self.called = True
+
+
+def setup_requests(monkeypatch, text):
+    resp = DummyResponse(text)
+    def fake_get(url, timeout):
+        return resp
+    monkeypatch.setattr(
+        lair.components.tools.search_tool.requests,
+        'get',
+        fake_get,
+        raising=False,
+    )
+    return resp
+
+
+def setup_extract(monkeypatch, result):
+    def fake_extract(text, include_comments=False, include_tables=False):
+        return result
+    monkeypatch.setattr(
+        lair.components.tools.search_tool.trafilatura,
+        'extract',
+        fake_extract,
+        raising=False,
+    )
+
+
+def make_tool(monkeypatch):
+    class DummyDDGS:
+        def __init__(self):
+            self.params = []
+        def text(self, query, max_results):
+            self.params.append(('text', query, max_results))
+            return []
+        def news(self, query, max_results):
+            self.params.append(('news', query, max_results))
+            return []
+    monkeypatch.setattr(lair.components.tools.search_tool.duckduckgo_search, 'DDGS', DummyDDGS)
+    return SearchTool()
+
+
+def test_get_content_truncates(monkeypatch):
+    lair.config.set('tools.search.max_length', 5, no_event=True)
+    lair.config.set('tools.search.timeout', 1, no_event=True)
+    setup_extract(monkeypatch, 'abcdefghij')
+    resp = setup_requests(monkeypatch, '<html>')
+    tool = make_tool(monkeypatch)
+    result = tool._get_content('http://x')
+    assert resp.called and result == 'abcde'
+
+
+def test_get_content_failure(monkeypatch, caplog):
+    lair.config.set('tools.search.max_length', 5, no_event=True)
+    lair.config.set('tools.search.timeout', 1, no_event=True)
+    setup_extract(monkeypatch, '')
+    setup_requests(monkeypatch, '<html>')
+    tool = make_tool(monkeypatch)
+    with caplog.at_level('DEBUG'):
+        result = tool._get_content('http://x')
+    assert result == '' and 'Failed to extract content' in caplog.text
+
+
+def test_get_content_exception(monkeypatch, caplog):
+    lair.config.set('tools.search.max_length', 5, no_event=True)
+    lair.config.set('tools.search.timeout', 1, no_event=True)
+    def boom(url, timeout):
+        raise RuntimeError('bad')
+    monkeypatch.setattr(
+        lair.components.tools.search_tool.requests,
+        'get',
+        boom,
+        raising=False,
+    )
+    tool = make_tool(monkeypatch)
+    with caplog.at_level('DEBUG'):
+        result = tool._get_content('http://x')
+    assert result == '' and 'Failed to get content' in caplog.text
+
+
+def test_search_web_success(monkeypatch):
+    lair.config.set('tools.search.max_results', 1, no_event=True)
+    tool = make_tool(monkeypatch)
+    monkeypatch.setattr(SearchTool, '_get_content', lambda self, url: 'text')
+    ddgs = tool.ddgs
+    def text_stub(q, max_results):
+        ddgs.params.append(('text', q, max_results))
+        return [
+            {'title': 'A', 'href': 'url1'},
+            {'title': 'B', 'href': 'url2'},
+        ]
+    ddgs.text = text_stub
+    result = tool.search_web('query')
+    assert result['results'][0]['title'] == 'A'
+    assert ('text', 'query', 4) in ddgs.params
+
+
+def test_search_web_error(monkeypatch):
+    lair.config.set('tools.search.max_results', 1, no_event=True)
+    tool = make_tool(monkeypatch)
+    monkeypatch.setattr(SearchTool, '_get_content', lambda self, url: '')
+    tool.ddgs.text = lambda q, max_results: []
+    assert tool.search_web('q') == {'error': 'Search failed'}
+
+
+def test_search_news_success(monkeypatch):
+    lair.config.set('tools.search.max_results', 1, no_event=True)
+    tool = make_tool(monkeypatch)
+    monkeypatch.setattr(SearchTool, '_get_content', lambda self, url: 'content')
+    ddgs = tool.ddgs
+    def news_stub(q, max_results):
+        ddgs.params.append(('news', q, max_results))
+        return [
+            {'date': 'd', 'title': 'T', 'url': 'nurl'},
+        ]
+    ddgs.news = news_stub
+    result = tool.search_news('query')
+    assert result['results'][0]['date'] == 'd'
+    assert ('news', 'query', 4) in ddgs.params
+
+
+def test_search_news_exception(monkeypatch):
+    lair.config.set('tools.search.max_results', 1, no_event=True)
+    tool = make_tool(monkeypatch)
+    def raise_exc(q, max_results):
+        raise ValueError('nope')
+    tool.ddgs.news = raise_exc
+    out = tool.search_news('q')
+    assert 'error' in out and 'nope' in out['error']
+


### PR DESCRIPTION
## Summary
- add new tests for `SearchTool`
- update stubs so pdfplumber has an `open` function
- document the new coverage improvement in the changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685231004f548320aa4967f06f3040cc