### PR TITLE
Increase ChatHistory test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - tests: Add stub for `pdfplumber.open` to avoid AttributeError in CI
 - tests: Enable coverage and add new utility tests
 - docker: Add lair into youtube image
+- tests: Increase ChatHistory coverage
 - tests: Increase ToolSet coverage
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -1,0 +1,110 @@
+import gc
+import copy
+
+import pytest
+
+import lair
+from lair.components.history.chat_history import ChatHistory
+from lair.components.history import schema
+from lair.components.history.chat_history import logger
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    original = lair.config.get('session.max_history_length', allow_not_found=True)
+    yield
+    lair.config.active['session.max_history_length'] = original
+    gc.collect()
+
+
+def test_validate_config_zero(monkeypatch):
+    lair.config.active['session.max_history_length'] = 0
+    warnings = []
+    monkeypatch.setattr(logger, 'warning', lambda msg: warnings.append(msg))
+    ChatHistory()
+    assert lair.config.active['session.max_history_length'] is None
+    assert warnings and 'Invalid value' in warnings[0]
+
+
+def test_add_message_and_errors():
+    hist = ChatHistory()
+    with pytest.raises(ValueError):
+        hist.add_message('tool', 'bad')
+    with pytest.raises(ValueError):
+        hist.add_message('unknown', 'bad')
+    hist.add_message('user', 'hello')
+    assert hist.get_messages()[0]['content'] == 'hello'
+
+
+def test_add_tool_messages_and_error():
+    hist = ChatHistory()
+    msgs = [
+        {'role': 'tool', 'content': None, 'tool_call_id': 'id'},
+        {'role': 'assistant', 'content': '', 'refusal': None, 'tool_calls': []},
+    ]
+    hist.add_tool_messages(msgs)
+    assert hist.get_messages()[0]['role'] == 'tool'
+    assert hist.get_messages()[0]['content'] == ''
+    with pytest.raises(ValueError):
+        hist.add_tool_messages([{'role': 'user', 'content': 'x'}])
+
+
+def test_copy_and_deepcopy_independent():
+    hist = ChatHistory()
+    hist.add_message('user', 'one')
+    shallow = copy.copy(hist)
+    deep = copy.deepcopy(hist)
+    hist.add_message('assistant', 'two')
+    assert len(shallow.get_messages()) == 1
+    assert len(deep.get_messages()) == 1
+    shallow._history[0]['content'] = 'shallow'
+    deep._history[0]['content'] = 'deep'
+    assert hist.get_messages()[0]['content'] == 'shallow'
+    shallow.add_message('user', 'x')
+    assert hist.num_messages() == 2
+    assert deep.get_messages()[0]['content'] == 'deep'
+
+
+def test_get_messages_truncate_and_extra():
+    lair.config.active['session.max_history_length'] = 2
+    hist = ChatHistory()
+    for i in range(3):
+        hist.add_message('user', str(i))
+    assert [m['content'] for m in hist.get_messages()] == ['1', '2']
+    extra = [{'role': 'system', 'content': 'x'}]
+    result = hist.get_messages(extra_messages=extra)
+    assert result[-1] == extra[0]
+    assert len(result) == 3
+    out = hist.get_messages_as_jsonl_string()
+    assert len(out.splitlines()) == 2
+
+
+def test_set_history_truncate(monkeypatch):
+    lair.config.active['session.max_history_length'] = 2
+    called = []
+    monkeypatch.setattr(schema, 'validate_messages', lambda m: called.append(m))
+    hist = ChatHistory()
+    messages = [
+        {'role': 'user', 'content': 'a'},
+        {'role': 'user', 'content': 'b'},
+        {'role': 'user', 'content': 'c'},
+    ]
+    hist.set_history(messages)
+    assert called and called[0] == messages
+    assert [m['content'] for m in hist.get_messages()] == ['b', 'c']
+    assert hist.finalized_index == 2
+
+
+def test_commit_and_rollback():
+    hist = ChatHistory()
+    hist.add_message('user', 'a')
+    hist.rollback()
+    assert hist.num_messages() == 0
+
+    hist.add_message('user', 'a')
+    hist.add_message('user', 'b')
+    hist.commit()
+    hist.add_message('user', 'c')
+    hist.rollback()
+    assert [m['content'] for m in hist.get_messages()] == ['a', 'b']
+


### PR DESCRIPTION
## Summary
- add extensive unit tests for `ChatHistory`
- document the new tests in the changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests/test_chat_history.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852381a67688320ad4aebc783cec85d