### PR TITLE
Fix ruff lint in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - tests: Increase ToolSet coverage
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example
+- tests: Fix ruff lint issues in test suite
 - tests: Add coverage for all chat sub-commands
 - tests: Add search tool coverage
 - tests: Add extra coverage for chat interface commands

--- a/tests/test_chat_interface_more.py
+++ b/tests/test_chat_interface_more.py
@@ -1,5 +1,4 @@
 import os
-import types
 import time
 import shutil
 import lair
@@ -74,6 +73,7 @@ def test_get_default_switch_session_id(monkeypatch):
     first = ci.chat_session.session_id
     ci._new_chat_session()
     second = ci.chat_session.session_id
+    assert second != first
     ci.last_used_session_id = first
     assert ci._get_default_switch_session_id() == first
     ci.last_used_session_id = 99

--- a/tests/test_comfy_caller_extra.py
+++ b/tests/test_comfy_caller_extra.py
@@ -18,7 +18,7 @@ class DummyNode:
 
 
 def test_monkey_patch_comfy_script(monkeypatch):
-    caller_mod = importlib.import_module("lair.comfy_caller")
+    importlib.import_module("lair.comfy_caller")
     cc = get_ComfyCaller()()
 
     class DummyConnector:
@@ -244,11 +244,11 @@ def test_workflow_image(monkeypatch):
     mod = importlib.import_module("lair.comfy_caller")
     monkeypatch.setattr(mod, "Workflow", DummyAsyncWF, raising=False)
     monkeypatch.setattr(mod, "CheckpointLoaderSimple", lambda n: ("m", "c", "v"), raising=False)
-    monkeypatch.setattr(cc, "_apply_loras", lambda m, c, l: (m + "+l", c + "+l"))
+    monkeypatch.setattr(cc, "_apply_loras", lambda m, c, loras: (m + "+l", c + "+l"))
     monkeypatch.setattr(mod, "CLIPTextEncode", lambda t, c: f"{t}:{c}", raising=False)
     monkeypatch.setattr(mod, "EmptyLatentImage", lambda *a: "latent", raising=False)
     monkeypatch.setattr(mod, "KSampler", lambda *a, **k: "latent2", raising=False)
-    monkeypatch.setattr(mod, "VAEDecode", lambda l, v: "img", raising=False)
+    monkeypatch.setattr(mod, "VAEDecode", lambda latent, v: "img", raising=False)
     monkeypatch.setattr(mod, "SaveImage", lambda img, prefix: DummyAsyncNode(["ok"]), raising=False)
     monkeypatch.setattr(mod.random, "randint", lambda a, b: 5)
     images = asyncio.run(
@@ -288,14 +288,14 @@ def test_workflow_outpaint(monkeypatch):
     mod = importlib.import_module("lair.comfy_caller")
     monkeypatch.setattr(mod, "Workflow", DummyAsyncWF, raising=False)
     monkeypatch.setattr(mod, "CheckpointLoaderSimple", lambda n: ("m", "c", "v"), raising=False)
-    monkeypatch.setattr(cc, "_apply_loras", lambda m, c, l: (m, c))
+    monkeypatch.setattr(cc, "_apply_loras", lambda m, c, loras: (m, c))
     monkeypatch.setattr(mod, "CLIPTextEncode", lambda p, c: f"cond:{p}", raising=False)
     monkeypatch.setattr(cc.__class__, "_image_to_base64", lambda self, img: "b64", raising=False)
     monkeypatch.setattr(mod, "ETNLoadImageBase64", lambda b: ("img", None), raising=False)
     monkeypatch.setattr(mod, "ImagePadForOutpaint", lambda *a, **k: ("pad", "mask"), raising=False)
     monkeypatch.setattr(mod, "VAEEncodeForInpaint", lambda *a, **k: "latent", raising=False)
     monkeypatch.setattr(mod, "KSampler", lambda *a, **k: "latent2", raising=False)
-    monkeypatch.setattr(mod, "VAEDecode", lambda l, v: "img2", raising=False)
+    monkeypatch.setattr(mod, "VAEDecode", lambda latent, v: "img2", raising=False)
     monkeypatch.setattr(mod, "SaveImage", lambda *a, **k: DummyAsyncNode(["img"]), raising=False)
     monkeypatch.setattr(mod.random, "randint", lambda a, b: 42)
     images = asyncio.run(

--- a/tests/test_python_tool.py
+++ b/tests/test_python_tool.py
@@ -1,7 +1,6 @@
 import subprocess
 import types
 import lair
-import pytest
 from lair.components.tools.python_tool import PythonTool
 
 

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,5 +1,4 @@
 import lair
-import pytest
 
 from lair.components.tools.search_tool import SearchTool
 


### PR DESCRIPTION
## Summary
- clean up unused imports in tests
- rename ambiguous variables for ruff
- ensure session switch test uses new session
- document ruff fix in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a902db548320ba2927740fff631e