### PR TITLE
Fix E501 lines per new Ruff checks

### DIFF
--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -54,7 +54,10 @@ class ChatInterfaceCommands:
                 "callback": lambda command, arguments, arguments_str: self.command_history_slice(
                     command, arguments, arguments_str
                 ),
-                "description": "Modify the history with a Python style slice string  (usage: /history-slice [slice], Slice format: start:stop:step)",
+                "description": (
+                    "Modify the history with a Python style slice string "
+                    "(usage: /history-slice [slice], Slice format: start:stop:step)"
+                ),
             },
             "/last-prompt": {
                 "callback": lambda command, arguments, arguments_str: self.command_last_prompt(
@@ -90,7 +93,9 @@ class ChatInterfaceCommands:
                 "callback": lambda command, arguments, arguments_str: self.command_load(
                     command, arguments, arguments_str
                 ),
-                "description": "Load a session from a file  (usage: /load [filename?], default filename is chat_session.json)",
+                "description": (
+                    "Load a session from a file  (usage: /load [filename?], default filename is chat_session.json)"
+                ),
             },
             "/messages": {
                 "callback": lambda command, arguments, arguments_str: self.command_messages(
@@ -126,7 +131,10 @@ class ChatInterfaceCommands:
                 "callback": lambda command, arguments, arguments_str: self.command_save(
                     command, arguments, arguments_str
                 ),
-                "description": "Save the current session to a file  (usage: /save [filename?], default filename is chat_session.json)",
+                "description": (
+                    "Save the current session to a file  (usage: /save [filename?], "
+                    "default filename is chat_session.json)"
+                ),
             },
             "/session": {
                 "callback": lambda command, arguments, arguments_str: self.command_session(
@@ -162,7 +170,10 @@ class ChatInterfaceCommands:
                 "callback": lambda command, arguments, arguments_str: self.command_set(
                     command, arguments, arguments_str
                 ),
-                "description": "Show configuration or set a configuration value for the current mode  (usage: /set ([key?] [value?])",
+                "description": (
+                    "Show configuration or set a configuration value for the current mode  "
+                    "(usage: /set ([key?] [value?])"
+                ),
             },
         }
 

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -75,8 +75,9 @@ class ComfyCaller:
         if self.is_comfy_script_imported is True:
             return
 
-        # ComfyScript behaves poorly with output and writes debugging with print() statements that can not be properly disabled.
-        # To deal with this, STDOUT is ignored on import.
+        # ComfyScript behaves poorly with output and writes debugging with
+        # print() statements that can not be properly disabled. To deal with
+        # this, STDOUT is ignored on import.
         with contextlib.redirect_stdout(io.StringIO()):
             from comfy_script.runtime import Workflow, load
 

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -63,7 +63,8 @@ class ChatHistory:
                 )
             else:
                 raise ValueError(
-                    "ChatHistory(): add_tool_messages() received a message with a role that wasn't 'tool' or 'assistant'"
+                    "ChatHistory(): add_tool_messages() received a message with "
+                    "a role that wasn't 'tool' or 'assistant'"
                 )
 
     def add_message(self, role, message, *, meta=None):
@@ -141,6 +142,8 @@ class ChatHistory:
             self.clear()
         else:
             logger.debug(
-                f"Rolling back history (finalized_index={self.finalized_index}, removing={len(self._history) - self.finalized_index})"
+                "Rolling back history "
+                f"(finalized_index={self.finalized_index}, "
+                f"removing={len(self._history) - self.finalized_index})"
             )
             self._history = self._history[0 : self.finalized_index]

--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -29,7 +29,9 @@ MESSAGES_SCHEMA = {
                                         "url": {
                                             "type": "string",
                                             "format": "uri",
-                                            "description": "A valid URI for the image, including base64-encoded data URLs.",
+                                            "description": (
+                                                "A valid URI for the image, including base64-encoded data URLs."
+                                            ),
                                         }
                                     },
                                     "required": ["url"],

--- a/lair/components/tools/file_tool.py
+++ b/lair/components/tools/file_tool.py
@@ -133,7 +133,10 @@ class FileTool:
                     "properties": {
                         "path": {
                             "type": "string",
-                            "description": "File path or glob pattern to read. (Supports all glob styles, including recursive `**`)",
+                            "description": (
+                                "File path or glob pattern to read. (Supports all glob styles, "
+                                "including recursive `**`)"
+                            ),
                         }
                     },
                     "required": ["path"],

--- a/lair/components/tools/tmux_tool.py
+++ b/lair/components/tools/tmux_tool.py
@@ -142,7 +142,10 @@ class TmuxTool:
                         },
                         "return_mode": {
                             "type": "string",
-                            "description": "Output mode: 'stream' (new terminal content) or 'screen' (string capture of the entire window).",
+                            "description": (
+                                "Output mode: 'stream' (new terminal content) or "
+                                "'screen' (string capture of the entire window)."
+                            ),
                             "enum": ["screen", "stream"],
                             "default": "stream",
                         },
@@ -191,7 +194,7 @@ class TmuxTool:
             pane.cmd("pipe-pane", "-o", f"cat >> {log_file_name}")
 
             logger.debug(
-                f"TmuxTool(): run(): window_id={window.get('window_id')}, pane_id={pane.get("pane_id")}, "
+                f"TmuxTool(): run(): window_id={window.get('window_id')}, pane_id={pane.get('pane_id')}, "
                 f"logfile={log_file_name}"
             )
 
@@ -220,11 +223,13 @@ class TmuxTool:
                     "properties": {
                         "keys": {
                             "type": "string",
-                            "description": "The key sequence to send. (libtmux style, literal=True by default)",
+                            "description": ("The key sequence to send. (libtmux style, literal=True by default)"),
                         },
                         "delay": {
                             "type": "number",
-                            "description": "Delay (in seconds) before capturing output. Set longer for long-running commands.",
+                            "description": (
+                                "Delay (in seconds) before capturing output. Set longer for long-running commands."
+                            ),
                             "default": 0.2,
                         },
                         "enter": {
@@ -239,7 +244,10 @@ class TmuxTool:
                         },
                         "return_mode": {
                             "type": "string",
-                            "description": "Output mode: 'stream' (new terminal content) or 'screen' (string capture of the entire window).",
+                            "description": (
+                                "Output mode: 'stream' (new terminal content) or "
+                                "'screen' (string capture of the entire window)."
+                            ),
                             "enum": ["screen", "stream"],
                             "default": "stream",
                         },
@@ -305,7 +313,9 @@ class TmuxTool:
             "type": "function",
             "function": {
                 "name": "read_new_output",
-                "description": "Read new output from the active window. Only new output since the last read is returned",
+                "description": (
+                    "Read new output from the active window. Only new output since the last read is returned"
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/lair/modules/comfy.py
+++ b/lair/modules/comfy.py
@@ -45,10 +45,10 @@ class Comfy:
 
         command_parser.add_argument("-b", "--batch-size", type=int, help="Batch size (default: 1)")
         command_parser.add_argument(
-            "-c", "--cfg", type=float, help=f'Classifier-free guidance scale (default: {defaults["cfg"]})'
+            "-c", "--cfg", type=float, help=f"Classifier-free guidance scale (default: {defaults['cfg']})"
         )
         command_parser.add_argument(
-            "-H", "--output-height", type=int, help=f'Output file height (default: {defaults["output_height"]})'
+            "-H", "--output-height", type=int, help=f"Output file height (default: {defaults['output_height']})"
         )
         command_parser.add_argument(
             "-l",
@@ -56,26 +56,33 @@ class Comfy:
             nargs="*",
             type=str,
             dest="loras",
-            help="Loras to use. Can be specified multiple times. These are processed in order. Command line usage overrides LoRAs in the settings. (format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})",
+            help=(
+                "Loras to use. Can be specified multiple times. These are processed in order. "
+                "Command line usage overrides LoRAs in the settings. "
+                "(format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})"
+            ),
         )
         command_parser.add_argument(
             "-m",
             "--model-name",
             type=str,
-            help=f'Name of the image diffusion model (default: {defaults["model_name"]})',
+            help=f"Name of the image diffusion model (default: {defaults['model_name']})",
         )
         command_parser.add_argument(
             "-n", "--negative-prompt", type=str, help="Negative prompt to use for image diffusion"
         )
         command_parser.add_argument(
-            "-N", "--steps", type=int, help=f'Number of sampling steps (default: {defaults["steps"]})'
+            "-N", "--steps", type=int, help=f"Number of sampling steps (default: {defaults['steps']})"
         )
         command_parser.add_argument(
             "-o",
             "--output-file",
             default=output_file,
             type=str,
-            help=f"File to write output to. When generating multiple images, the basename becomes a prefix. (default: {output_file})",
+            help=(
+                f"File to write output to. When generating multiple images, "
+                f"the basename becomes a prefix. (default: {output_file})"
+            ),
         )
         command_parser.add_argument("-p", "--prompt", type=str, help="Prompt to use for image diffusion.")
         command_parser.add_argument("-P", "--prompt-file", type=str, help="File name to read a prompt from.")
@@ -84,28 +91,33 @@ class Comfy:
             "--repeat",
             default=1,
             type=int,
-            help="Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)",
+            help=(
+                "Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)"
+            ),
         )
         command_parser.add_argument(
-            "-s", "--sampler", type=str, help=f'Sampler to use for image diffusion (default: {defaults["sampler"]})'
+            "-s", "--sampler", type=str, help=f"Sampler to use for image diffusion (default: {defaults['sampler']})"
         )
         command_parser.add_argument(
             "-S",
             "--scheduler",
             type=str,
-            help=f'Scheduler to use for image diffusion (default: {defaults["scheduler"]})',
+            help=f"Scheduler to use for image diffusion (default: {defaults['scheduler']})",
         )
         command_parser.add_argument(
             "-u", "--comfy-url", default=comfy_url, help=f"URL for the Comfy UI API (default: {comfy_url})"
         )
         command_parser.add_argument(
-            "-w", "--output-width", type=int, help=f'Output file width (default: {defaults["output_width"]})'
+            "-w", "--output-width", type=int, help=f"Output file width (default: {defaults['output_width']})"
         )
         command_parser.add_argument(
             "-x",
             "--seed",
             type=int,
-            help=f'The seed to use when sampling (default: {defaults["seed"] if defaults["seed"] is not None else "random"})',
+            help=(
+                "The seed to use when sampling (default: "
+                f"{defaults['seed'] if defaults['seed'] is not None else 'random'})"
+            ),
         )
 
     def _add_argparse_hunyuan_video_t2v(self, sub_parser):
@@ -116,25 +128,25 @@ class Comfy:
 
         command_parser.add_argument("-b", "--batch-size", type=int, help="Batch size (default: 1)")
         command_parser.add_argument(
-            "-c", "--clip-name-1", type=str, help=f'Name of the first clip model (default: {defaults["clip_name_1"]})'
+            "-c", "--clip-name-1", type=str, help=f"Name of the first clip model (default: {defaults['clip_name_1']})"
         )
         command_parser.add_argument(
-            "-C", "--clip-name-2", type=str, help=f'Name of the second clip model (default: {defaults["clip_name_2"]})'
+            "-C", "--clip-name-2", type=str, help=f"Name of the second clip model (default: {defaults['clip_name_2']})"
         )
         command_parser.add_argument(
-            "-f", "--frame-rate", type=int, help=f'Batch size (default: {defaults["frame_rate"]})'
+            "-f", "--frame-rate", type=int, help=f"Batch size (default: {defaults['frame_rate']})"
         )
         command_parser.add_argument(
             "-F",
             "--num-frames",
             type=int,
-            help=f'Number of frames to generate (default: {defaults["num_frames"]}, must be N * 4 + 1)',
+            help=f"Number of frames to generate (default: {defaults['num_frames']}, must be N * 4 + 1)",
         )
         command_parser.add_argument(
-            "-g", "--guidance_scale", type=float, help=f'Guidance scale (default: {defaults["guidance_scale"]})'
+            "-g", "--guidance_scale", type=float, help=f"Guidance scale (default: {defaults['guidance_scale']})"
         )
         command_parser.add_argument(
-            "-H", "--output-height", type=int, dest="height", help=f'Output file height (default: {defaults["height"]})'
+            "-H", "--output-height", type=int, dest="height", help=f"Output file height (default: {defaults['height']})"
         )
         command_parser.add_argument(
             "-l",
@@ -142,26 +154,33 @@ class Comfy:
             nargs="*",
             type=str,
             dest="loras",
-            help="Loras to use. Can be specified multiple times. These are processed in order. Command line usage overrides LoRAs in the settings. (format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})",
+            help=(
+                "Loras to use. Can be specified multiple times. These are processed in order. "
+                "Command line usage overrides LoRAs in the settings. "
+                "(format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})"
+            ),
         )
         command_parser.add_argument(
             "-m",
             "--model-name",
             type=str,
-            help=f'Name of the image diffusion model (default: {defaults["model_name"]})',
+            help=f"Name of the image diffusion model (default: {defaults['model_name']})",
         )
         command_parser.add_argument(
             "-M",
             "--model-weight-dtype",
             type=str,
-            help=f'Dtype to use for the model (default: {defaults["model_weight_dtype"]})',
+            help=f"Dtype to use for the model (default: {defaults['model_weight_dtype']})",
         )
         command_parser.add_argument(
             "-o",
             "--output-file",
             default=output_file,
             type=str,
-            help=f"File to write output to. When generating multiple images, the basename becomes a prefix. (default: {output_file})",
+            help=(
+                f"File to write output to. When generating multiple images, "
+                f"the basename becomes a prefix. (default: {output_file})"
+            ),
         )
         command_parser.add_argument(
             "-p", "--prompt", type=str, help="Prompt to use. (auto-prompt is disabled when this is provided)"
@@ -177,28 +196,33 @@ class Comfy:
             "--repeat",
             default=1,
             type=int,
-            help="Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)",
+            help=(
+                "Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)"
+            ),
         )
         command_parser.add_argument(
-            "-s", "--sampler", type=str, help=f'Sampler to use for image diffusion (default: {defaults["sampler"]})'
+            "-s", "--sampler", type=str, help=f"Sampler to use for image diffusion (default: {defaults['sampler']})"
         )
         command_parser.add_argument(
             "-S",
             "--scheduler",
             type=str,
-            help=f'Scheduler to use for image diffusion (default: {defaults["scheduler"]})',
+            help=f"Scheduler to use for image diffusion (default: {defaults['scheduler']})",
         )
         command_parser.add_argument(
             "-u", "--comfy-url", default=comfy_url, help=f"URL for the Comfy UI API (default: {comfy_url})"
         )
         command_parser.add_argument(
-            "-w", "--output-width", type=int, dest="width", help=f'Output file width (default: {defaults["width"]})'
+            "-w", "--output-width", type=int, dest="width", help=f"Output file width (default: {defaults['width']})"
         )
         command_parser.add_argument(
             "-x",
             "--seed",
             type=int,
-            help=f'The seed to use when sampling (default: {defaults["seed"] if defaults["seed"] is not None else "random"})',
+            help=(
+                "The seed to use when sampling (default: "
+                f"{defaults['seed'] if defaults['seed'] is not None else 'random'})"
+            ),
         )
 
     def _add_argparse_ltxv_i2v(self, sub_parser):
@@ -211,55 +235,64 @@ class Comfy:
             "-a",
             "--auto-prompt-extra",
             type=str,
-            help="Content to add after the generated prompt (When --prompt or --prompt-file is provided, this is ignored)",
+            help=(
+                "Content to add after the generated prompt (When --prompt or "
+                "--prompt-file is provided, this is ignored)"
+            ),
         )
         command_parser.add_argument(
             "-A",
             "--auto-prompt-suffix",
             type=str,
-            help="Content to add to the end of the generated prompt (When --prompt or --prompt-file is provided, this is ignored)",
+            help=(
+                "Content to add to the end of the generated prompt (When --prompt "
+                "or --prompt-file is provided, this is ignored)"
+            ),
         )
         command_parser.add_argument("-b", "--batch-size", type=int, help="Batch size (default: 1)")
         command_parser.add_argument(
-            "-c", "--cfg", type=float, help=f'Classifier-free guidance scale (default: {defaults["cfg"]})'
+            "-c", "--cfg", type=float, help=f"Classifier-free guidance scale (default: {defaults['cfg']})"
         )
         command_parser.add_argument(
-            "-C", "--clip-name", type=str, help=f'Name of the clip model (default: {defaults["clip_name"]})'
+            "-C", "--clip-name", type=str, help=f"Name of the clip model (default: {defaults['clip_name']})"
         )
         command_parser.add_argument(
             "-f",
             "--frame-rate-saving",
             type=int,
-            help=f'Frame rate for saving -- different than conditioning (default: {defaults["frame_rate_save"]})',
+            help=f"Frame rate for saving -- different than conditioning (default: {defaults['frame_rate_save']})",
         )
         command_parser.add_argument(
             "-F",
             "--num-frames",
             type=int,
-            help=f'Number of frames to generate (default: {defaults["num_frames"]}, must be N * 8 + 1)',
+            help=f"Number of frames to generate (default: {defaults['num_frames']}, must be N * 8 + 1)",
         )
         command_parser.add_argument("-i", "--image", type=str, required=True, help="Input image file to use (required)")
         command_parser.add_argument(
             "-m",
             "--model-name",
             type=str,
-            help=f'Name of the image diffusion model (default: {defaults["model_name"]})',
+            help=f"Name of the image diffusion model (default: {defaults['model_name']})",
         )
         command_parser.add_argument(
             "-n", "--negative-prompt", type=str, help="Negative prompt to use for image diffusion"
         )
         command_parser.add_argument(
-            "-N", "--steps", type=int, help=f'Number of sampling steps (default: {defaults["steps"]})'
+            "-N", "--steps", type=int, help=f"Number of sampling steps (default: {defaults['steps']})"
         )
         command_parser.add_argument(
             "-o",
             "--output-file",
             default=output_file,
             type=str,
-            help=f"File to write output to. When generating multiple images, the basename becomes a prefix. (default: {output_file})",
+            help=(
+                f"File to write output to. When generating multiple images, "
+                f"the basename becomes a prefix. (default: {output_file})"
+            ),
         )
         command_parser.add_argument(
-            "-O", "--output-format", type=str, help=f'Output format to use (default: {defaults["output_format"]}'
+            "-O", "--output-format", type=str, help=f"Output format to use (default: {defaults['output_format']}"
         )
         command_parser.add_argument(
             "-p", "--prompt", type=str, help="Prompt to use. (auto-prompt is disabled when this is provided)"
@@ -275,22 +308,26 @@ class Comfy:
             "--repeat",
             default=1,
             type=int,
-            help="Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)",
+            help=(
+                "Number of times to repeat. Total images generated is number of repeats times batch size. (default: 1)"
+            ),
         )
         command_parser.add_argument(
             "-R",
             "--frame-rate-conditioning",
             type=int,
-            help=f'Frame rate for conditioning -- different than saving (default: {defaults["frame_rate_conditioning"]})',
+            help=(
+                f"Frame rate for conditioning -- different than saving (default: {defaults['frame_rate_conditioning']})"
+            ),
         )
         command_parser.add_argument(
-            "-s", "--sampler", type=str, help=f'Sampler to use for image diffusion (default: {defaults["sampler"]})'
+            "-s", "--sampler", type=str, help=f"Sampler to use for image diffusion (default: {defaults['sampler']})"
         )
         command_parser.add_argument(
             "-S",
             "--scheduler",
             type=str,
-            help=f'Scheduler to use for image diffusion (default: {defaults["scheduler"]})',
+            help=f"Scheduler to use for image diffusion (default: {defaults['scheduler']})",
         )
         command_parser.add_argument(
             "-u", "--comfy-url", default=comfy_url, help=f"URL for the Comfy UI API (default: {comfy_url})"
@@ -299,7 +336,10 @@ class Comfy:
             "-x",
             "--seed",
             type=int,
-            help=f'The seed to use when sampling (default: {defaults["seed"] if defaults["seed"] is not None else "random"})',
+            help=(
+                "The seed to use when sampling (default: "
+                f"{defaults['seed'] if defaults['seed'] is not None else 'random'})"
+            ),
         )
 
     def _add_argparse_ltxv_prompt(self, sub_parser):
@@ -320,7 +360,10 @@ class Comfy:
             "--output-file",
             default=output_file,
             type=str,
-            help=f"File to write output to. When generating multiple images, the basename becomes a prefix. (default: {output_file})",
+            help=(
+                f"File to write output to. When generating multiple images, "
+                f"the basename becomes a prefix. (default: {output_file})"
+            ),
         )
         command_parser.add_argument(
             "-r", "--repeat", default=1, type=int, help="Number of times to repeat. (default: 1)"
@@ -333,29 +376,35 @@ class Comfy:
             "--seed",
             type=int,
             dest="florence_seed",
-            help=f'The seed to use with the Florence model (default: {defaults["florence_seed"] if defaults["florence_seed"] is not None else "random"})',
+            help=(
+                "The seed to use with the Florence model (default: "
+                f"{defaults['florence_seed'] if defaults['florence_seed'] is not None else 'random'})"
+            ),
         )
 
     def _add_argparse_outpaint(self, sub_parser):
         command_parser = sub_parser.add_parser("outpaint", help="Outpaint images")
         defaults = self.comfy.defaults["outpaint"]
         comfy_url = lair.config.get("comfy.url")
-        padding_default = f'{defaults["padding_top"]}x{defaults["padding_right"]}x{defaults["padding_bottom"]}x{defaults["padding_left"]}'
+        padding_default = (
+            f"{defaults['padding_top']}x{defaults['padding_right']}x"
+            f"{defaults['padding_bottom']}x{defaults['padding_left']}"
+        )
 
         command_parser.add_argument(
-            "-c", "--cfg", type=float, help=f'Classifier-free guidance scale (default: {defaults["cfg"]})'
+            "-c", "--cfg", type=float, help=f"Classifier-free guidance scale (default: {defaults['cfg']})"
         )
         command_parser.add_argument(
-            "-d", "--denoise", type=float, help=f'Denoise level (default: {defaults["denoise"]})'
+            "-d", "--denoise", type=float, help=f"Denoise level (default: {defaults['denoise']})"
         )
         command_parser.add_argument(
-            "-f", "--feathering", type=float, help=f'Feathering pixels (default: {defaults["feathering"]})'
+            "-f", "--feathering", type=float, help=f"Feathering pixels (default: {defaults['feathering']})"
         )
         command_parser.add_argument(
             "-g",
             "--grow-mask_by",
             type=float,
-            help=f'How many pixels to use for the grow_mask_by setting (default: {defaults["grow_mask_by"]})',
+            help=f"How many pixels to use for the grow_mask_by setting (default: {defaults['grow_mask_by']})",
         )
         command_parser.add_argument(
             "-l",
@@ -363,19 +412,23 @@ class Comfy:
             nargs="*",
             type=str,
             dest="loras",
-            help="Loras to use. Can be specified multiple times. These are processed in order. Command line usage overrides LoRAs in the settings. (format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})",
+            help=(
+                "Loras to use. Can be specified multiple times. These are processed in order. "
+                "Command line usage overrides LoRAs in the settings. "
+                "(format either: {name}, {name}:{weight}, or {name}:{weight}:{clip_weight})"
+            ),
         )
         command_parser.add_argument(
             "-m",
             "--model-name",
             type=str,
-            help=f'Name of the image diffusion model (default: {defaults["model_name"]})',
+            help=f"Name of the image diffusion model (default: {defaults['model_name']})",
         )
         command_parser.add_argument(
             "-n", "--negative-prompt", type=str, help="Negative prompt to use for image diffusion"
         )
         command_parser.add_argument(
-            "-N", "--steps", type=int, help=f'Number of sampling steps (default: {defaults["steps"]})'
+            "-N", "--steps", type=int, help=f"Number of sampling steps (default: {defaults['steps']})"
         )
         command_parser.add_argument("-p", "--prompt", type=str, help="Prompt to use for image diffusion.")
         command_parser.add_argument("-P", "--prompt-file", type=str, help="File name to read a prompt from.")
@@ -394,13 +447,13 @@ class Comfy:
             help="Do not perform upscaling for files that already have an output file",
         )
         command_parser.add_argument(
-            "-s", "--sampler", type=str, help=f'Sampler to use for image diffusion (default: {defaults["sampler"]})'
+            "-s", "--sampler", type=str, help=f"Sampler to use for image diffusion (default: {defaults['sampler']})"
         )
         command_parser.add_argument(
             "-S",
             "--scheduler",
             type=str,
-            help=f'Scheduler to use for image diffusion (default: {defaults["scheduler"]})',
+            help=f"Scheduler to use for image diffusion (default: {defaults['scheduler']})",
         )
         command_parser.add_argument(
             "-u", "--comfy-url", default=comfy_url, help=f"URL for the Comfy UI API (default: {comfy_url})"
@@ -409,7 +462,10 @@ class Comfy:
             "-x",
             "--seed",
             type=int,
-            help=f'The seed to use when sampling (default: {defaults["seed"] if defaults["seed"] is not None else "random"})',
+            help=(
+                "The seed to use when sampling (default: "
+                f"{defaults['seed'] if defaults['seed'] is not None else 'random'})"
+            ),
         )
         command_parser.add_argument("outpaint_files", type=str, nargs="+", help="File(s) to outpaint")
 
@@ -419,7 +475,7 @@ class Comfy:
         comfy_url = lair.config.get("comfy.url")
 
         command_parser.add_argument(
-            "-m", "--model-name", type=str, help=f'Upscale model  (default: {defaults["model_name"]})'
+            "-m", "--model-name", type=str, help=f"Upscale model  (default: {defaults['model_name']})"
         )
         command_parser.add_argument(
             "-r", "--recursive", action="store_true", help="Recursively process all files in provided paths"

--- a/lair/modules/util.py
+++ b/lair/modules/util.py
@@ -20,7 +20,11 @@ class Util:
             type=str,
             dest="attachments",
             action="append",
-            help="Specify one or more image files to attach to the request. Multiple files may be provided by repeating the argument. Ensure the model you are interacting with supports file attachments. Globs are supported.",
+            help=(
+                "Specify one or more image files to attach to the request. Multiple files "
+                "may be provided by repeating the argument. Ensure the model you are interacting "
+                "with supports file attachments. Globs are supported."
+            ),
         )
         (parser.add_argument("-c", "--content", type=str, help="Content to use"),)
         parser.add_argument("-C", "--content-file", type=str, help="Filename containing content use")

--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -107,11 +107,14 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
         Args:
             rows (Iterable): A 2-dimensional array of row data.
-            column_names (Optional[List[str]]): A list of names for the columns. When provided, these names are used in the header,
-                and also as keys for column_formatters if specified.
-            column_formatters (Optional[Dict[str, Callable]]): A dictionary mapping column names to formatter functions.
-                For any cell in a column with an associated formatter, the cell value is passed to the formatter,
-                and its return value is used directly (without applying self.style()).
+            column_names (Optional[List[str]]): A list of names for the columns.
+                When provided, these names are used in the header, and also as
+                keys for column_formatters if specified.
+            column_formatters (Optional[Dict[str, Callable]]): A dictionary
+                mapping column names to formatter functions. For any cell in a
+                column with an associated formatter, the cell value is passed to
+                the formatter, and its return value is used directly (without
+                applying self.style()).
                 Note: This option only takes effect if column_names is provided.
             style (Optional[str]): Base rich style to apply to the table.
             markup (bool): If False, all column names and row data (except those formatted via column_formatters)
@@ -335,7 +338,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
     def messages_to_str(self, messages):
         lines = []
         for message in messages:
-            lines.append(f'{message["role"].upper()}: {message["content"]}')
+            lines.append(f"{message['role'].upper()}: {message['content']}")
 
         return "\n".join(lines)
 

--- a/lair/sessions/base_chat_session.py
+++ b/lair/sessions/base_chat_session.py
@@ -110,7 +110,8 @@ class BaseChatSession(abc.ABC):
 
         if not (user_message and assistant_reply):
             logger.debug(
-                f"auto_generate_title(): failed: Could not find a user message and assistant reply  (session={self.session_id})"
+                "auto_generate_title(): failed: Could not find a user message "
+                f"and assistant reply  (session={self.session_id})"
             )
             return None
 

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -145,11 +145,13 @@ def read_pdf(filename, *, enforce_limits=False):
             if enforce_limits and len(contents) > limit:
                 if not lair.config.get("misc.text_attachment_truncate"):
                     raise Exception(
-                        f"Attachment size exceeds limit: file={filename}, size={os.path.getsize(filename)}, limit={limit}"
+                        "Attachment size exceeds limit: "
+                        f"file={filename}, size={os.path.getsize(filename)}, limit={limit}"
                     )
                 else:
                     logger.warning(
-                        f"Attachment size exceeds limit: file={filename}, size={os.path.getsize(filename)}, limit={limit}"
+                        "Attachment size exceeds limit: "
+                        f"file={filename}, size={os.path.getsize(filename)}, limit={limit}"
                     )
                     contents = contents[0:limit]
                     break


### PR DESCRIPTION
## Summary
- address E501 issues raised by new Ruff checks
- wrap long help strings and comments

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `poetry run pytest -q` *(fails: Required test coverage of 65% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6873303d49dc8320bea3df8521b1c7c1