### PR TITLE
Fix import order for ruff I001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - tests: Add ComfyCaller SSL and URL handling coverage
 - tests: Add PythonTool unit tests
 - tests: Increase tmux tool coverage
+- internal: Fix import order to satisfy new ruff checks
 
 # v0.8.1 - Bug fixes
 

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -21,26 +21,26 @@ import ctypes
 import importlib
 import io
 import secrets
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 import lair
 from lair.logging import logger  # noqa
-from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from comfy_script.runtime import Workflow
     from comfy_script.runtime.nodes import (
         BasicGuider,
         BasicScheduler,
+        CheckpointLoaderSimple,
         CLIPLoader,
         CLIPTextEncode,
-        CheckpointLoaderSimple,
         DownloadAndLoadFlorence2Model,
         DualCLIPLoader,
-        ETNLoadImageBase64,
         EmptyHunyuanLatentVideo,
         EmptyLatentImage,
+        ETNLoadImageBase64,
         Florence2Run,
         FluxGuidance,
         ImagePadForOutpaint,
@@ -48,11 +48,11 @@ if TYPE_CHECKING:
         ImageUpscaleWithModel,
         KSampler,
         KSamplerSelect,
+        LoraLoader,
         LTXVConditioning,
         LTXVImgToVideo,
         LTXVPreprocess,
         LTXVScheduler,
-        LoraLoader,
         ModelSamplingSD3,
         RandomNoise,
         SamplerCustom,

--- a/lair/util/__init__.py
+++ b/lair/util/__init__.py
@@ -19,9 +19,9 @@ from lair.util.core import (
     safe_int,
     save_file,
     save_json_file,
+    slice_from_str,
     slurp_file,
     strip_escape_codes,
-    slice_from_str,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- fix import order problems in `ComfyCaller`
- fix import order problems in utility module
- document new ruff fixes

## Testing
- `python -m compileall -q lair`
- `ruff check lair --select I`
- `ruff check lair`
- `pytest -q` *(fails: AttributeError: module 'lair' has no attribute 'events')*

------
https://chatgpt.com/codex/tasks/task_e_68733c45518883208b80d20e909ea910