### PR TITLE
Fix test cleanup path assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - tests: Enable coverage and add new utility tests
 - docker: Add lair into youtube image
 - tests: Increase ChatHistory coverage
+- tests: Fix Python tool cleanup path assertions
 - tests: Increase ToolSet coverage
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,9 +1,9 @@
 import datetime
 import json
 import os
+import zoneinfo
 
 import openai
-import zoneinfo
 
 import lair
 import lair.components.tools

--- a/tests/test_python_tool.py
+++ b/tests/test_python_tool.py
@@ -61,7 +61,7 @@ def test_run_python_timeout(monkeypatch):
     monkeypatch.setattr("lair.components.tools.python_tool.subprocess.run", fake_run)
     out = tool.run_python("print(1)")
     assert out["error"].startswith("ERROR: Timeout")
-    assert ["docker", "rm", "-f", "cid"] in calls
+    assert [tool._docker, "rm", "-f", "cid"] in calls
 
 
 def test_run_python_success(monkeypatch):
@@ -87,7 +87,7 @@ def test_run_python_success(monkeypatch):
     assert out["stdout"] == "out"
     assert out["stderr"] == "err"
     assert "exit_status" not in out
-    assert ["docker", "rm", "-f", "cid"] in calls
+    assert [tool._docker, "rm", "-f", "cid"] in calls
 
 
 def test_run_python_exception(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure python tool tests use correct docker path
- sort imports in OpenAI chat session
- document python tool cleanup assertion fix

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876465d3ac88320828e72456c62ba1a