### PR TITLE
Fix Optional types in sessions

### DIFF
--- a/lair/sessions/base_chat_session.py
+++ b/lair/sessions/base_chat_session.py
@@ -7,12 +7,13 @@ import lair.reporting
 import lair.sessions.serializer
 import lair.util.prompt_template
 from lair.components.history import ChatHistory
+from lair.components.tools import ToolSet
 from lair.logging import logger  # noqa
 
 
 class BaseChatSession(abc.ABC):
     @abc.abstractmethod
-    def __init__(self, *, history=None, tool_set: lair.components.tools.ToolSet = None):
+    def __init__(self, *, history: Optional[ChatHistory] = None, tool_set: Optional[ToolSet] = None):
         """
         Arguments:
            history: History class to provide. Defaults to a new ChatHistory()
@@ -27,10 +28,10 @@ class BaseChatSession(abc.ABC):
         self.session_title = None  # Short title for the session
 
         self.history = history or ChatHistory()
-        self.tool_set = tool_set or lair.components.tools.ToolSet()
+        self.tool_set = tool_set or ToolSet()
 
     @abc.abstractmethod
-    def invoke(self, messages: list = None, disable_system_prompt=False):
+    def invoke(self, messages: Optional[List[Dict[str, Any]]] = None, disable_system_prompt: bool = False):
         """
         Call the underlying model without altering state (no history)
 
@@ -40,7 +41,7 @@ class BaseChatSession(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def invoke_with_tools(self, messages: list = None, disable_system_prompt=False):
+    def invoke_with_tools(self, messages: Optional[List[Dict[str, Any]]] = None, disable_system_prompt: bool = False):
         """
         Call the underlying model without altering state (no history)
 

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 import zoneinfo
+from typing import Any, Dict, List, Optional
 
 import openai
 
@@ -10,12 +11,14 @@ import lair.components.tools
 import lair.reporting
 from lair.logging import logger
 
+from lair.components.history import ChatHistory
+from lair.components.tools import ToolSet
 from .base_chat_session import BaseChatSession
 
 
 class OpenAIChatSession(BaseChatSession):
-    def __init__(self, *, history=None, tool_set: lair.components.tools.ToolSet = None):
-        super().__init__(history=history)
+    def __init__(self, *, history: Optional[ChatHistory] = None, tool_set: Optional[ToolSet] = None):
+        super().__init__(history=history, tool_set=tool_set)
         self.openai = None
         self.recreate_openai_client()
 
@@ -31,7 +34,13 @@ class OpenAIChatSession(BaseChatSession):
     def recreate_openai_client(self):
         self._get_openai_client()
 
-    def invoke(self, messages: list = None, disable_system_prompt=False, model=None, temperature=None):
+    def invoke(
+        self,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        disable_system_prompt: bool = False,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+    ):
         """
         Call the underlying model without altering state (no history)
         """
@@ -83,7 +92,7 @@ class OpenAIChatSession(BaseChatSession):
             tool_messages.append(tool_response_messsage)
             logger.debug(f"Tool result: {tool_response_messsage}")
 
-    def invoke_with_tools(self, messages: list = None, disable_system_prompt=False):
+    def invoke_with_tools(self, messages: Optional[List[Dict[str, Any]]] = None, disable_system_prompt: bool = False):
         """
         Call the underlying model without altering state (no history)
 


### PR DESCRIPTION
## Summary
- refine typing for BaseChatSession to avoid implicit Optional defaults
- update OpenAIChatSession to use the new types

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: 63 errors)*
- `ruff format lair`
- `mypy lair` *(fails: 12 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764a3c0d308320bfe2fee58c322717