### PR TITLE
Fix mypy issues with type annotations

### DIFF
--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -15,7 +15,7 @@ import lair
 
 
 class ReportingSingletoneMeta(type):
-    _instances = {}
+    _instances: dict[type, "Reporting"] = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -226,7 +226,7 @@ def get_attachments_content(filenames):
     return content_parts, messages
 
 
-def edit_content_in_editor(content: str, suffix: str = None) -> str | None:
+def edit_content_in_editor(content: str, suffix: str | None = None) -> str | None:
     """
     Edit the content in an external editor
     Return the new content or None if unchanged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 lair = "lair.cli.run:start"
+
+[tool.mypy]
+mypy_path = "stubs"

--- a/stubs/comfy_script/__init__.pyi
+++ b/stubs/comfy_script/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/stubs/comfy_script/runtime/__init__.pyi
+++ b/stubs/comfy_script/runtime/__init__.pyi
@@ -1,0 +1,9 @@
+from typing import Any, ContextManager
+
+class Workflow(ContextManager[Any]):
+    ...
+
+queue: Any
+
+
+def load(url: str) -> None: ...

--- a/stubs/comfy_script/runtime/nodes/__init__.pyi
+++ b/stubs/comfy_script/runtime/nodes/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/stubs/lmdb/__init__.pyi
+++ b/stubs/lmdb/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def open(*args: Any, **kwargs: Any) -> Any: ...


### PR DESCRIPTION
## Summary
- add type annotations in events and reporting
- correct optional parameter typing in util core
- annotate OpenAI chat session and ensure client is initialized
- add local stubs for comfy_script and lmdb
- configure mypy to use local stubs
- **restore event variable comments**

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: UP031 etc.)*
- `ruff format lair`
- `mypy lair`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68764ee72ff083208d24112d9a2b2763