### PR TITLE
Increase test coverage for config and tmux_tool

### DIFF
--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+
+import lair
+import importlib
+
+config_module = importlib.import_module("lair.config")
+
+
+def make_config_env(tmp_path, monkeypatch):
+    """Prepare HOME and patch read_package_file for config initialization."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path, exist_ok=True)
+    orig_read = lair.util.read_package_file
+
+    def fake_read(path, name):
+        if name == "config.yaml":
+            return "default_mode: test\ntest:\n  chat.attachments_enabled: false\n"
+        return orig_read(path, name)
+
+    monkeypatch.setattr(lair.util, "read_package_file", fake_read)
+    monkeypatch.setattr(lair.events, "fire", lambda *a, **k: None)
+
+
+def test_configuration_initializes_and_loads(tmp_path, monkeypatch):
+    make_config_env(tmp_path, monkeypatch)
+    cfg = config_module.Configuration()
+    config_file = tmp_path / ".lair" / "config.yaml"
+    assert config_file.is_file()
+    with open(config_file) as fd:
+        assert "default_mode: test" in fd.read()
+    assert cfg.active_mode == "test"
+    assert cfg.get("chat.attachments_enabled") is False
+
+
+def test_add_config_errors_and_change_mode(tmp_path, monkeypatch):
+    make_config_env(tmp_path, monkeypatch)
+    cfg = config_module.Configuration()
+    # default_mode not found should raise SystemExit
+    with pytest.raises(SystemExit):
+        cfg._add_config({"default_mode": "missing"})
+    # unknown mode change
+    with pytest.raises(Exception):
+        cfg.change_mode("missing")
+
+
+def test_update_get_set_and_cast(monkeypatch, tmp_path):
+    make_config_env(tmp_path, monkeypatch)
+    cfg = config_module.Configuration()
+    # force update
+    cfg.update({"chat.enable_toolbar": False}, force=True)
+    assert cfg.get("chat.enable_toolbar") is False
+    # get unknown
+    with pytest.raises(ValueError):
+        cfg.get("nope")
+    # set unknown key
+    with pytest.raises(config_module.ConfigUnknownKeyException):
+        cfg.set("nope", 1)
+    # invalid bool value triggers ConfigInvalidType
+    with pytest.raises(config_module.ConfigInvalidType):
+        cfg.set("chat.attachments_enabled", "maybe")
+    # cast empty string for int returns None
+    assert cfg._cast_value("session.max_history_length", "") is None


### PR DESCRIPTION
## Summary
- add unit tests for configuration loading and validation
- add error-path and connection tests for TmuxTool

## Testing
- `poetry run python -m compileall -q lair`
- `poetry run ruff check lair tests`
- `poetry run mypy lair`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778e2dcf2c83209cd6fd36a00bf752