### PR TITLE
Fix chat command loader import

### DIFF
--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -4,6 +4,8 @@ import traceback
 
 import lair.logging
 import lair.util
+import lair.module_loader
+import lair.reporting
 from lair.logging import logger
 
 

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,57 @@
+import sys
+import types
+import importlib
+import click
+from click.testing import CliRunner
+
+STUB_MODULES = [
+    'lair.cli.chat_interface',
+    'openai',
+    'requests',
+    'trafilatura',
+    'PIL',
+    'diffusers',
+    'transformers',
+    'torch',
+    'comfy_script',
+    'lair.comfy_caller',
+]
+
+
+def test_cli_runner_chat_command(monkeypatch):
+    for name in STUB_MODULES:
+        mod = types.ModuleType(name)
+        if name == 'lair.cli.chat_interface':
+            mod.ChatInterface = object
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    import lair.reporting  # ensure submodule is registered
+    run = importlib.import_module('lair.cli.run')
+
+    called = {'flag': False}
+
+    class Dummy:
+        def __init__(self, parser):
+            pass
+
+        def run(self, args):
+            called['flag'] = True
+
+    def fake_init_subcommands(parser):
+        sub = parser.add_subparsers(dest='subcommand')
+        chat_parser = sub.add_parser('chat', help='chat help')
+        return {'chat': Dummy(chat_parser)}
+
+    monkeypatch.setattr(run, 'init_subcommands', fake_init_subcommands)
+
+    @click.command(context_settings={'ignore_unknown_options': True})
+    @click.argument('args', nargs=-1, type=click.UNPROCESSED)
+    def cli(args):
+        sys.argv = ['lair'] + list(args)
+        run.start()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['chat'])
+
+    assert result.exit_code == 0
+    assert called['flag']


### PR DESCRIPTION
## Summary
- import `lair.module_loader` and `lair.reporting` so the CLI chat command runs
- add regression test using click's `CliRunner` to exercise `lair chat`

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: Found 77 errors)*
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787f717bd883209ed3a571eecc0649