### PR TITLE
Increase session coverage

### DIFF
--- a/tests/test_base_chat_session.py
+++ b/tests/test_base_chat_session.py
@@ -110,7 +110,9 @@ def test_serialization_helpers(monkeypatch):
     monkeypatch.setattr(lair.sessions.serializer, "save", lambda s, f: actions.append(("save", f)))
     monkeypatch.setattr(lair.sessions.serializer, "load", lambda s, f: actions.append(("load", f)))
     monkeypatch.setattr(lair.sessions.serializer, "session_to_dict", lambda s: {"id": 1})
-    monkeypatch.setattr(lair.sessions.serializer, "update_session_from_dict", lambda s, d: actions.append(("update", d)))
+    monkeypatch.setattr(
+        lair.sessions.serializer, "update_session_from_dict", lambda s, d: actions.append(("update", d))
+    )
     session.save_to_file("f")
     session.load_from_file("f")
     assert session.to_dict() == {"id": 1}

--- a/tests/test_base_chat_session_additional.py
+++ b/tests/test_base_chat_session_additional.py
@@ -1,0 +1,27 @@
+import lair
+from lair.sessions.base_chat_session import BaseChatSession
+
+
+class PassThroughSession(BaseChatSession):
+    def __init__(self):
+        super().__init__()
+
+    def invoke(self, messages=None, disable_system_prompt=False, model=None, temperature=None):
+        # call parent abstract method to execute pass line
+        super().invoke(messages, disable_system_prompt)
+        return "ok"
+
+    def invoke_with_tools(self, messages=None, disable_system_prompt=False):
+        super().invoke_with_tools(messages, disable_system_prompt)
+        return "ok", []
+
+    def list_models(self, ignore_errors=False):
+        super().list_models(ignore_errors=ignore_errors)
+        return []
+
+
+def test_super_methods_execute():
+    session = PassThroughSession()
+    assert session.invoke() == "ok"
+    assert session.invoke_with_tools() == ("ok", [])
+    assert session.list_models() == []

--- a/tests/test_sessions_init.py
+++ b/tests/test_sessions_init.py
@@ -1,0 +1,15 @@
+import pytest
+import lair
+from lair.sessions import get_chat_session, OpenAIChatSession
+import lair.sessions.openai_chat_session as ocs
+
+
+def test_get_chat_session_openai(monkeypatch):
+    monkeypatch.setattr(lair.events, "subscribe", lambda *a, **k: None)
+    session = get_chat_session("openai_chat")
+    assert isinstance(session, OpenAIChatSession)
+
+
+def test_get_chat_session_unknown():
+    with pytest.raises(ValueError):
+        get_chat_session("bogus")


### PR DESCRIPTION
## Summary
- add tests for session factory
- test abstract base chat session method passthroughs
- format long line in existing test

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787ece49f0832081bff3304561794c