### PR TITLE
Fix lint issues from new ruff checks

### DIFF
--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -77,7 +77,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
         if id_or_alias:
             try:
                 self._switch_to_session(id_or_alias)
-            except lair.sessions.UnknownSessionException:
+            except lair.sessions.UnknownSessionError:
                 if create_session_if_missing:
                     if not self.session_manager.is_alias_available(id_or_alias):
                         if isinstance(lair.util.safe_int(id_or_alias), int):
@@ -299,8 +299,8 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                             When False, it logs an error instead.
 
         Raises:
-          lair.sessions.UnknownSessionException: If the session ID is unknown
-                                                 and `raise_exceptions` is True.
+          lair.sessions.UnknownSessionError: If the session ID is unknown
+            and `raise_exceptions` is True.
         """
         try:
             with lair.events.defer_events():
@@ -309,7 +309,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                 self._rebuild_chat_session()
                 if old_session_id != self.chat_session.session_id:
                     self.last_used_session_id = old_session_id
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             if raise_exceptions:
                 raise
             else:
@@ -351,7 +351,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
         try:
             self._switch_to_session(id_or_alias)
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             self.reporting.user_error(f"ERROR: Unknown session: {id_or_alias}")
 
     def _handle_session_set_alias(self):

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -456,7 +456,7 @@ class ChatInterfaceCommands:
             # If the current session was deleted, recreate it
             try:
                 self.session_manager.get_session_id(self.chat_session.session_id)
-            except lair.sessions.session_manager.UnknownSessionException:
+            except lair.sessions.session_manager.UnknownSessionError:
                 self._new_chat_session()
 
     def command_session_new(self, command, arguments, arguments_str):

--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -23,7 +23,7 @@ def init_subcommands(parent_parser):
             for alias in aliases:
                 commands[alias] = commands[name]
         except Exception as error:
-            raise Exception("Failed to load module '%s': %s" % (name, error))
+            raise Exception(f"Failed to load module '{name}': {error}") from error
 
     return commands
 
@@ -32,9 +32,10 @@ def parse_arguments():
     class HelpFormatter(argparse.HelpFormatter):
         def _format_action(self, action):
             if type(action) is argparse._SubParsersAction._ChoicesPseudoAction:
-                return "  %-40.40s - %s\n" % (self._format_action_invocation(action), self._expand_help(action))
+                invocation = self._format_action_invocation(action)
+                return f"  {invocation:<40.40} - {self._expand_help(action)}\n"
             else:
-                return super(HelpFormatter, self)._format_action(action)
+                return super()._format_action(action)
 
     parser = argparse.ArgumentParser(formatter_class=HelpFormatter)
     parser.add_argument("--debug", "-d", action="store_true", default=False, help="Enable debugging output")
@@ -53,7 +54,7 @@ def parse_arguments():
     arguments = parser.parse_args()
 
     if arguments.version:
-        print(f"Lair v{lair.version()}")
+        sys.stdout.write(f"Lair v{lair.version()}\n")
         sys.exit(0)
     elif not arguments.subcommand:
         parser.print_help()
@@ -100,7 +101,7 @@ def start():
     except KeyboardInterrupt:
         sys.exit("Received interrupt.  Exiting")
     except Exception as error:
-        logger.error("An error has occurred: (%s)\n" % error)
+        logger.error("An error has occurred: (%s)\n", error)
         if "arguments" not in locals() or lair.util.is_debug_enabled():
             traceback.print_exc()
             sys.exit(1)

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -115,11 +115,11 @@ class ComfyCaller:
         # this, STDOUT is ignored on import.
         with contextlib.redirect_stdout(io.StringIO()):
             runtime_module = importlib.import_module("comfy_script.runtime")
-            load = getattr(runtime_module, "load")
-            Workflow_local = getattr(runtime_module, "Workflow")
+            load = runtime_module.load
+            workflow_local = runtime_module.Workflow
 
             globals()["load"] = load
-            globals()["Workflow"] = Workflow_local
+            globals()["Workflow"] = workflow_local
 
             if lair.config.get("comfy.verify_ssl") is False:
                 self._monkey_patch_comfy_script()
@@ -185,7 +185,7 @@ class ComfyCaller:
             with open(image, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode("utf-8")
         else:
-            raise ValueError("Conversion of image to base64 not supported for type: %s" % type(image))
+            raise ValueError(f"Conversion of image to base64 not supported for type: {type(image)}")
 
     def _ensure_watch_thread(self):
         runtime = importlib.import_module("comfy_script.runtime")
@@ -472,19 +472,21 @@ class ComfyCaller:
                 image, image_resize_height, image_resize_width, "bilinear", True, 32, 0, 0, None, "disabled"
             )
             florence2_model = DownloadAndLoadFlorence2Model(florence_model_name, "fp16", "sdpa", None)
-            _, _, prompt, _ = Florence2Run(
+            _, _, caption_prompt, _ = Florence2Run(
                 image, florence2_model, "", "more_detailed_caption", True, False, 256, 3, True, "", florence_seed
             )
-            prompt = StringReplaceMtb(prompt, "image", "video")
-            prompt = StringReplaceMtb(prompt, "photo", "video")
-            prompt = StringReplaceMtb(prompt, "painting", "video")
-            prompt = StringReplaceMtb(prompt, "illustration", "video")
-            prompt = StringFunctionPysssss("append", "no", prompt, auto_prompt_extra, auto_prompt_suffix)
+            caption_prompt = StringReplaceMtb(caption_prompt, "image", "video")
+            caption_prompt = StringReplaceMtb(caption_prompt, "photo", "video")
+            caption_prompt = StringReplaceMtb(caption_prompt, "painting", "video")
+            caption_prompt = StringReplaceMtb(caption_prompt, "illustration", "video")
+            caption_prompt = StringFunctionPysssss(
+                "append", "no", caption_prompt, auto_prompt_extra, auto_prompt_suffix
+            )
 
         prompts = []
-        for prompt in prompt.wait()._output["text"]:
+        for individual_prompt in caption_prompt.wait()._output["text"]:
             # Encoding is used so that the save file bytes() support can write the output
-            prompts.append(prompt.encode())
+            prompts.append(individual_prompt.encode())
 
         return prompts
 

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -71,7 +71,7 @@ class ChatHistory:
         if role == "tool":
             raise ValueError("add_message(): Role of tool is invalid. Use add_tool_message()")
         elif role not in self.ALLOWED_ROLES:
-            raise ValueError("add_message(): Unknown role: %s" % role)
+            raise ValueError(f"add_message(): Unknown role: {role}")
 
         self._history.append(
             {

--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -127,4 +127,4 @@ def validate_messages(messages):
         else:
             error_location = "root"
 
-        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}")
+        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}") from error

--- a/lair/components/tools/__init__.py
+++ b/lair/components/tools/__init__.py
@@ -33,7 +33,7 @@ def get_tool_classes_from_str(tool_names_str):
         name = name.strip()
 
         if name not in TOOLS:
-            raise ValueError("Unknown tool name: %s" % tool_names_str)
+            raise ValueError(f"Unknown tool name: {tool_names_str}")
 
         classes.append(TOOLS[name])
 

--- a/lair/components/tools/file_tool.py
+++ b/lair/components/tools/file_tool.py
@@ -148,10 +148,7 @@ class FileTool:
         try:
             workspace = os.path.abspath(lair.config.get("tools.file.path"))
 
-            if not os.path.isabs(path):
-                pattern = os.path.join(workspace, path)
-            else:
-                pattern = path
+            pattern = os.path.join(workspace, path) if not os.path.isabs(path) else path
 
             file_paths = glob.glob(pattern, recursive=True)
             if not file_paths:
@@ -165,7 +162,7 @@ class FileTool:
                 elif not os.path.isfile(file_path):
                     continue  # Skip non-files (e.g., directories)
 
-                with open(file_path, "r") as f:
+                with open(file_path) as f:
                     content = f.read()
                     relative_path = os.path.relpath(file_path, workspace)
                     file_contents[relative_path] = content

--- a/lair/modules/util.py
+++ b/lair/modules/util.py
@@ -123,7 +123,7 @@ class Util:
         session_manager = lair.sessions.SessionManager()
         try:
             session_manager.switch_to_session(arguments.session, chat_session)
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             if not arguments.allow_create_session:
                 logger.error(f"Unknown session: {arguments.session}")
                 sys.exit(1)

--- a/lair/sessions/__init__.py
+++ b/lair/sessions/__init__.py
@@ -1,5 +1,5 @@
 from .openai_chat_session import OpenAIChatSession
-from .session_manager import SessionManager, UnknownSessionException
+from .session_manager import SessionManager, UnknownSessionError
 
 
 def get_chat_session(session_type, *args, **kwargs):
@@ -12,6 +12,6 @@ def get_chat_session(session_type, *args, **kwargs):
 __all__ = [
     "OpenAIChatSession",
     "SessionManager",
-    "UnknownSessionException",
+    "UnknownSessionError",
     "get_chat_session",
 ]

--- a/lair/sessions/session_manager.py
+++ b/lair/sessions/session_manager.py
@@ -1,22 +1,21 @@
+import importlib
 import json
 import os
-
-import importlib
 from typing import Any
-
-lmdb: Any = importlib.import_module("lmdb")
 
 import lair
 import lair.sessions.serializer
 import lair.util
 from lair.logging import logger
 
+lmdb: Any = importlib.import_module("lmdb")
+
 # For clarity:
 #   A `chat_session` is a ChatSession object
 #   A `session` is a serialized session dict from lair.sessions.serializer
 
 
-class UnknownSessionException(Exception):
+class UnknownSessionError(Exception):
     pass
 
 
@@ -79,7 +78,7 @@ class SessionManager:
                     return int(id_or_alias)
 
         if raise_exception:
-            raise UnknownSessionException(f"Unknown session: {id_or_alias}")
+            raise UnknownSessionError(f"Unknown session: {id_or_alias}")
         else:
             return None
 
@@ -206,7 +205,7 @@ class SessionManager:
         try:
             if self.get_session_id(alias):
                 return False
-        except UnknownSessionException:
+        except UnknownSessionError:
             return True
 
     def set_alias(self, id_or_alias, new_alias):

--- a/tests/test_chat_commands.py
+++ b/tests/test_chat_commands.py
@@ -28,7 +28,7 @@ def setup_ci(monkeypatch):
             return orig_get(id_or_alias, raise_exception)
         except Exception:
             if raise_exception:
-                raise lair.sessions.session_manager.UnknownSessionException("Unknown")
+                raise lair.sessions.session_manager.UnknownSessionError("Unknown")
             return None
 
     monkeypatch.setattr(ci.session_manager, "get_session_id", patched_get)

--- a/tests/test_chat_interface_more.py
+++ b/tests/test_chat_interface_more.py
@@ -108,7 +108,7 @@ def test_handle_session_switch(monkeypatch):
 
     def fake_switch(id_or_alias, chat_session):
         if id_or_alias == "unknown":
-            raise lair.sessions.UnknownSessionException("Unknown")
+            raise lair.sessions.UnknownSessionError("Unknown")
         return original(id_or_alias, chat_session)
 
     monkeypatch.setattr(ci.session_manager, "switch_to_session", fake_switch)

--- a/tests/test_chat_interface_new.py
+++ b/tests/test_chat_interface_new.py
@@ -14,7 +14,7 @@ def setup_interface(monkeypatch):
 def test_init_starting_session_create(monkeypatch):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: True)
     ci.chat_session.session_alias = None
@@ -26,7 +26,7 @@ def test_init_starting_session_create(monkeypatch):
 def test_init_starting_session_integer_error(monkeypatch, caplog):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: False)
     monkeypatch.setattr(lair.util, "safe_int", int)


### PR DESCRIPTION
## Summary
- adjust CLI run module to satisfy ruff
- update comfy_caller imports and prompt variable names
- fix chat history and schema lint warnings
- clean up tools modules
- rename session manager exception to `UnknownSessionError`
- update tests for renamed exception

## Testing
- `python -m compileall -q lair`
- `ruff check --isolated lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788dc06188832087d79f03fbe539f3