### PR TITLE
Fix new ruff warnings

### DIFF
--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -397,7 +397,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                 self.commands[command]["callback"](command, arguments, arguments_str)
                 return True
             except Exception as error:
-                self.reporting.error("Command failed: %s" % error)
+                self.reporting.error(f"Command failed: {error}")
                 return False
         else:
             self.reporting.user_error("Unknown command")
@@ -444,7 +444,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
             else:
                 return self._handle_request_chat(request)
         except Exception as error:
-            self.reporting.error("Chat failed: %s" % error)
+            self.reporting.error(f"Chat failed: {error}")
             return False
 
     def startup_message(self):
@@ -502,9 +502,9 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
     def _generate_toolbar_template_flags(self):
         def flag(character, parameter):
             if lair.config.active[parameter]:
-                return "<flag.on>%s</flag.on>" % character.upper()
+                return f"<flag.on>{character.upper()}</flag.on>"
             else:
-                return "<flag.off>%s</flag.off>" % character.lower()
+                return f"<flag.off>{character.lower()}</flag.off>"
 
         return (
             flag("l", "chat.multiline_input")
@@ -521,7 +521,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
         if time.time() < self.flash_message_expiration:
             return prompt_toolkit.formatted_text.HTML(
-                "<bottom-toolbar.flash>%s</bottom-toolbar.flash>" % self.flash_message
+                f"<bottom-toolbar.flash>{self.flash_message}</bottom-toolbar.flash>"
             )
 
         try:
@@ -531,7 +531,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
             return prompt_toolkit.formatted_text.HTML(template)
         except Exception as error:
-            logger.error("Unable to render toolbar: %s" % error)
+            logger.error("Unable to render toolbar: %s", error)
             logger.error("Disabling toolbar")
             lair.config.active["chat.enable_toolbar"] = False
             return ""

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -5,8 +5,8 @@ import shlex
 import lair
 from lair.logging import logger
 from lair.util.argparse import (
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
     ErrorRaisingArgumentParser,
 )
 
@@ -227,7 +227,7 @@ class ChatInterfaceCommands:
                         lair.util.save_file(filename, response + "\n")
                         self.reporting.system_message(f"Section saved  ({len(response)} bytes)")
                     else:
-                        print(response)
+                        self.reporting.print_rich(response)
                 else:
                     logger.error("Extract failed: No matching section found")
             else:
@@ -255,10 +255,7 @@ class ChatInterfaceCommands:
 
             if edited_jsonl_str is not None:
                 try:
-                    if not edited_jsonl_str.strip():
-                        new_messages = []
-                    else:
-                        new_messages = lair.util.decode_jsonl(edited_jsonl_str)
+                    new_messages = [] if not edited_jsonl_str.strip() else lair.util.decode_jsonl(edited_jsonl_str)
                 except Exception as error:
                     logger.error(f"Failed to decode edited history JSONL: {error}")
                     return
@@ -333,10 +330,10 @@ class ChatInterfaceCommands:
 
         try:
             new_arguments = parser.parse_args(shlex.split(arguments_str))
-        except ArgumentParserHelpException as error:  # Display help with styles
+        except ArgumentParserHelpError as error:  # Display help with styles
             self.reporting.system_message(str(error), disable_markdown=True)
             return
-        except ArgumentParserExitException:  # Ignore exits
+        except ArgumentParserExitError:  # Ignore exits
             return
 
         self.print_config_report(
@@ -485,6 +482,6 @@ class ChatInterfaceCommands:
             key = arguments[0]
             value = "" if len(arguments) == 1 else arguments_str[len(arguments[0]) + 1 :].strip()
             if key not in lair.config.active:
-                self.reporting.user_error("ERROR: Unknown key: %s" % key)
+                self.reporting.user_error(f"ERROR: Unknown key: {key}")
             else:
                 lair.config.set(key, value)

--- a/lair/cli/chat_interface_completer.py
+++ b/lair/cli/chat_interface_completer.py
@@ -59,7 +59,7 @@ class ChatInterfaceCompleter(Completer):
             yield Completion(f"/set {key} {value}", display=value, start_position=-len(text))
 
     def _get_set_key_completion(self, prefix, text):
-        for key in lair.config.active.keys():
+        for key in lair.config.active:
             if key.startswith("_"):
                 continue
             if key.startswith(prefix) and prefix != key:

--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -23,7 +23,7 @@ def init_subcommands(parent_parser):
             for alias in aliases:
                 commands[alias] = commands[name]
         except Exception as error:
-            raise Exception("Failed to load module '%s': %s" % (name, error))
+            raise Exception(f"Failed to load module '{name}': {error}") from error
 
     return commands
 
@@ -32,9 +32,9 @@ def parse_arguments():
     class HelpFormatter(argparse.HelpFormatter):
         def _format_action(self, action):
             if type(action) is argparse._SubParsersAction._ChoicesPseudoAction:
-                return "  %-40.40s - %s\n" % (self._format_action_invocation(action), self._expand_help(action))
+                return f"  {self._format_action_invocation(action):<40.40} - {self._expand_help(action)}\n"
             else:
-                return super(HelpFormatter, self)._format_action(action)
+                return super()._format_action(action)
 
     parser = argparse.ArgumentParser(formatter_class=HelpFormatter)
     parser.add_argument("--debug", "-d", action="store_true", default=False, help="Enable debugging output")
@@ -53,7 +53,7 @@ def parse_arguments():
     arguments = parser.parse_args()
 
     if arguments.version:
-        print(f"Lair v{lair.version()}")
+        sys.stdout.write(f"Lair v{lair.version()}\n")
         sys.exit(0)
     elif not arguments.subcommand:
         parser.print_help()
@@ -100,7 +100,7 @@ def start():
     except KeyboardInterrupt:
         sys.exit("Received interrupt.  Exiting")
     except Exception as error:
-        logger.error("An error has occurred: (%s)\n" % error)
+        logger.error("An error has occurred: (%s)\n", error)
         if "arguments" not in locals() or lair.util.is_debug_enabled():
             traceback.print_exc()
             sys.exit(1)

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -115,11 +115,11 @@ class ComfyCaller:
         # this, STDOUT is ignored on import.
         with contextlib.redirect_stdout(io.StringIO()):
             runtime_module = importlib.import_module("comfy_script.runtime")
-            load = getattr(runtime_module, "load")
-            Workflow_local = getattr(runtime_module, "Workflow")
+            load = runtime_module.load
+            workflow_local = runtime_module.Workflow
 
             globals()["load"] = load
-            globals()["Workflow"] = Workflow_local
+            globals()["Workflow"] = workflow_local
 
             if lair.config.get("comfy.verify_ssl") is False:
                 self._monkey_patch_comfy_script()
@@ -185,7 +185,7 @@ class ComfyCaller:
             with open(image, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode("utf-8")
         else:
-            raise ValueError("Conversion of image to base64 not supported for type: %s" % type(image))
+            raise ValueError(f"Conversion of image to base64 not supported for type: {type(image)}")
 
     def _ensure_watch_thread(self):
         runtime = importlib.import_module("comfy_script.runtime")
@@ -482,9 +482,9 @@ class ComfyCaller:
             prompt = StringFunctionPysssss("append", "no", prompt, auto_prompt_extra, auto_prompt_suffix)
 
         prompts = []
-        for prompt in prompt.wait()._output["text"]:
+        for prompt_text in prompt.wait()._output["text"]:
             # Encoding is used so that the save file bytes() support can write the output
-            prompts.append(prompt.encode())
+            prompts.append(prompt_text.encode())
 
         return prompts
 

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -71,7 +71,7 @@ class ChatHistory:
         if role == "tool":
             raise ValueError("add_message(): Role of tool is invalid. Use add_tool_message()")
         elif role not in self.ALLOWED_ROLES:
-            raise ValueError("add_message(): Unknown role: %s" % role)
+            raise ValueError(f"add_message(): Unknown role: {role}")
 
         self._history.append(
             {

--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -127,4 +127,4 @@ def validate_messages(messages):
         else:
             error_location = "root"
 
-        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}")
+        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}") from error

--- a/lair/components/tools/__init__.py
+++ b/lair/components/tools/__init__.py
@@ -33,7 +33,7 @@ def get_tool_classes_from_str(tool_names_str):
         name = name.strip()
 
         if name not in TOOLS:
-            raise ValueError("Unknown tool name: %s" % tool_names_str)
+            raise ValueError(f"Unknown tool name: {tool_names_str}")
 
         classes.append(TOOLS[name])
 

--- a/lair/components/tools/file_tool.py
+++ b/lair/components/tools/file_tool.py
@@ -148,10 +148,7 @@ class FileTool:
         try:
             workspace = os.path.abspath(lair.config.get("tools.file.path"))
 
-            if not os.path.isabs(path):
-                pattern = os.path.join(workspace, path)
-            else:
-                pattern = path
+            pattern = os.path.join(workspace, path) if not os.path.isabs(path) else path
 
             file_paths = glob.glob(pattern, recursive=True)
             if not file_paths:
@@ -165,7 +162,7 @@ class FileTool:
                 elif not os.path.isfile(file_path):
                     continue  # Skip non-files (e.g., directories)
 
-                with open(file_path, "r") as f:
+                with open(file_path) as f:
                     content = f.read()
                     relative_path = os.path.relpath(file_path, workspace)
                     file_contents[relative_path] = content

--- a/lair/components/tools/python_tool.py
+++ b/lair/components/tools/python_tool.py
@@ -38,7 +38,7 @@ class PythonTool:
                     "Run a python script and return the output. "
                     "This is not a REPL. Repeat calls are independent. Output must be printed to be retrieved. "
                     "STDOUT, STDERR are returned.) "
-                    "(extra_modules=%(extra_modules)s, timeout=%(timeout)s)" % settings
+                    f"(extra_modules={settings['extra_modules']}, timeout={settings['timeout']})"
                 ),
                 "parameters": {
                     "type": "object",

--- a/lair/components/tools/tmux_tool.py
+++ b/lair/components/tools/tmux_tool.py
@@ -113,7 +113,7 @@ class TmuxTool:
             try:
                 self._connect_to_tmux()
             except Exception as connect_error:
-                raise Exception(f"Tmux server unavailable: {connect_error}")
+                raise Exception(f"Tmux server unavailable: {connect_error}") from connect_error
 
     def _get_output(self, return_mode, *, prune_line=None, window_id=None):
         """

--- a/lair/components/tools/tool_set.py
+++ b/lair/components/tools/tool_set.py
@@ -68,11 +68,7 @@ class ToolSet:
         return enabled_tools
 
     def all_flags_enabled(self, flags):
-        for flag in flags:
-            if not lair.config.get(flag):
-                return False
-
-        return True
+        return all(lair.config.get(flag) for flag in flags)
 
     def get_all_tools(self):
         """

--- a/lair/config.py
+++ b/lair/config.py
@@ -5,11 +5,11 @@ import lair.util
 from lair.logging import logger  # noqa
 
 
-class ConfigUnknownKeyException(Exception):
+class ConfigUnknownKeyError(Exception):
     pass
 
 
-class ConfigInvalidType(Exception):
+class ConfigInvalidTypeError(Exception):
     pass
 
 
@@ -86,7 +86,7 @@ class Configuration:
         if default_mode is None:
             return
         elif default_mode not in self.modes:
-            sys.exit("ERROR: Configuration file's default_mode is not found: %s" % default_mode)
+            sys.exit(f"ERROR: Configuration file's default_mode is not found: {default_mode}")
         else:
             self.change_mode(default_mode)
 
@@ -132,7 +132,7 @@ class Configuration:
             return
 
         if key not in self.modes["_default"]:
-            raise ConfigUnknownKeyException("Unknown Key: %s" % key)
+            raise ConfigUnknownKeyError(f"Unknown Key: {key}")
 
         try:
             value = self._cast_value(key, value)
@@ -141,8 +141,8 @@ class Configuration:
             self.active[key] = value
             if not no_event:
                 lair.events.fire("config.update")
-        except ValueError:
-            raise ConfigInvalidType(f"value '{value}' cannot be cast as '{self.types[key]}'")
+        except ValueError as error:
+            raise ConfigInvalidTypeError(f"value '{value}' cannot be cast as '{self.types[key]}'") from error
 
     def _cast_value(self, key, value):
         current_type = self.types[key]
@@ -151,7 +151,7 @@ class Configuration:
                 return True
             if value in {False, "false", "False"}:
                 return False
-            raise ConfigInvalidType(f"value '{value}' cannot be cast as '{current_type}' [key={key}]")
+            raise ConfigInvalidTypeError(f"value '{value}' cannot be cast as '{current_type}' [key={key}]")
 
         if value is None and current_type is str:
             return ""

--- a/lair/events.py
+++ b/lair/events.py
@@ -1,7 +1,6 @@
 import itertools
 import weakref
 from contextlib import contextmanager
-
 from typing import Any, Callable
 
 from lair.logging import logger
@@ -60,9 +59,11 @@ def unsubscribe(subscription_id):
     return False
 
 
-def fire(event_name, data={}):
+def fire(event_name, data=None):
     """Triggers an event, calling all subscribed handlers."""
     global _deferring
+    if data is None:
+        data = {}
     if _deferring:
         if _squash_duplicates and any(event[0] == event_name and event[1] == data for event in _deferred_events):
             return  # Skip duplicate events

--- a/lair/logging.py
+++ b/lair/logging.py
@@ -42,8 +42,5 @@ def _log_color(level_name):
 
 def _emit_with_color(handler, record):
     message = handler.format(record)
-    if record.color:
-        text = Text(record.prefix + message, style=record.color)
-    else:
-        text = Text(record.prefix + message)
+    text = Text(record.prefix + message, style=record.color) if record.color else Text(record.prefix + message)
     console.print(text)

--- a/lair/module_loader.py
+++ b/lair/module_loader.py
@@ -27,10 +27,10 @@ class ModuleLoader:
     def _get_module_files(self, path):
         module_files = []
 
-        for root, dirs, files in os.walk(os.path.abspath(path)):
+        for root, _dirs, files in os.walk(os.path.abspath(path)):
             for name in files:
                 if name.endswith(".py") and name != "__init__.py" and not name.startswith("."):
-                    module_files.append("%s/%s" % (root, name))
+                    module_files.append(f"{root}/{name}")
 
         return module_files
 
@@ -50,17 +50,17 @@ class ModuleLoader:
         module_info.update({"name": name})  # Add the name into our stored module_info
 
         if name in self.modules:
-            raise Exception("Unable to register repeat name: %s" % name)
+            raise Exception(f"Unable to register repeat name: {name}")
         elif name in self.commands:
-            raise Exception("Unable to register repeat command name: %s" % name)
+            raise Exception(f"Unable to register repeat command name: {name}")
         else:
-            logger.debug("Registered module: %s" % name)
+            logger.debug("Registered module: %s", name)
             self.modules[name] = module_info
             self.commands[name] = module_info["class"]
 
             for alias in module_info.get("aliases", []):
                 if alias in self.commands:
-                    raise Exception("Unable to register repeat command / alias: %s" % name)
+                    raise Exception(f"Unable to register repeat command / alias: {name}")
                 self.commands[alias] = module_info["class"]
 
     def _validate_module(self, module):
@@ -72,10 +72,10 @@ class ModuleLoader:
             try:
                 jsonschema.validate(instance=module._module_info(), schema=ModuleLoader.MODULE_INFO_SCHEMA)
             except jsonschema.ValidationError as error:
-                raise Exception("Invalid _module_info: %s" % error)
+                raise Exception(f"Invalid _module_info: {error}") from error
 
     def import_file(self, filename, module_path):
-        logger.debug("Importing file: %s" % filename)
+        logger.debug("Importing file: %s", filename)
 
         try:
             spec = importlib.util.spec_from_file_location(filename, filename)
@@ -85,11 +85,11 @@ class ModuleLoader:
             self._validate_module(module)
             self._register_module(module, module_path)
         except Exception as error:
-            logger.warning("Error loading module from file '%s': %s" % (filename, error))
+            logger.warning("Error loading module from file '%s': %s", filename, error)
             return
 
     def load_modules_from_path(self, module_path):
-        logger.debug("Loading modules from path: %s" % module_path)
+        logger.debug("Loading modules from path: %s", module_path)
         files = self._get_module_files(module_path)
 
         for filename in sorted(files):

--- a/lair/modules/comfy.py
+++ b/lair/modules/comfy.py
@@ -11,8 +11,8 @@ import lair.cli
 import lair.comfy_caller
 from lair.logging import logger  # noqa
 from lair.util.argparse import (
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
     ErrorRaisingArgumentParser,
 )
 
@@ -511,10 +511,10 @@ class Comfy:
                 try:
                     params = chat_command_parser.parse_args(new_arguments)
                     params.comfy_url = lair.config.get("comfy.url")
-                except ArgumentParserHelpException as error:  # Display help with styles
+                except ArgumentParserHelpError as error:  # Display help with styles
                     chat_interface.reporting.error(str(error), show_exception=False)
                     return
-                except ArgumentParserExitException:  # Ignore exits
+                except ArgumentParserExitError:  # Ignore exits
                     return
             except argparse.ArgumentError as error:
                 message = str(error)

--- a/lair/modules/util.py
+++ b/lair/modules/util.py
@@ -33,8 +33,10 @@ class Util:
             "--include-filenames",
             action="store_true",
             default=None,
-            help="Provide filenames of attached files (via misc.provide_attachment_filenames, default=%s)"
-            % lair.config.get("misc.provide_attachment_filenames"),
+            help=(
+                "Provide filenames of attached files (via misc.provide_attachment_filenames, "
+                f"default={lair.config.get('misc.provide_attachment_filenames')}"
+            ),
         )
         parser.add_argument("-i", "--instructions", type=str, help="Instructions for the request")
         parser.add_argument(
@@ -69,7 +71,7 @@ class Util:
         return response
 
     def _read_file(self, filename):
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             return fd.read()
 
     def _get_instructions(self, arguments):
@@ -173,8 +175,8 @@ class Util:
             lair.config.update(config_backup)
             session_manager.refresh_from_chat_session(chat_session)
 
+        reporting = lair.reporting.Reporting()
         if arguments.markdown:
-            reporting = lair.reporting.Reporting()
             reporting.llm_output(response)
         else:
-            print(response)
+            reporting.print_rich(response)

--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -3,6 +3,7 @@ import math
 import re
 import sys
 import traceback
+from typing import Any
 
 import rich
 import rich.columns
@@ -10,8 +11,6 @@ import rich.highlighter
 import rich.markdown
 import rich.text
 import rich.traceback
-
-from typing import Any
 
 import lair
 
@@ -50,7 +49,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         if lair.config.get("style.messages_command.syntax_highlight"):
             rich.print_json(json_str, indent=None)
         else:
-            print(json_str)
+            self.console.print(json_str)
 
     def style(self, *args, **kwargs):
         """Style a string using rich.
@@ -78,10 +77,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
             return
 
         if column_names is None:
-            if automatic_column_names:
-                column_names = list(rows_of_dicts[0].keys())
-            else:
-                column_names = None
+            column_names = list(rows_of_dicts[0].keys()) if automatic_column_names else None
         else:
             column_names = list(column_names)
 
@@ -346,27 +342,29 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         display_value=None,
         log=False,
         inverse=False,
-        styles=[  # shades in red, yellow, and green
-            "rgb(51,0,0)",
-            "rgb(102,0,0)",
-            "rgb(153,0,0)",
-            "rgb(204,0,0)",
-            "rgb(255,0,0)",
-            "rgb(51,51,0)",
-            "rgb(102,102,0)",
-            "rgb(153,153,0)",
-            "rgb(204,204,0)",
-            "rgb(255,255,0)",
-            "rgb(0,51,0)",
-            "rgb(0,102,0)",
-            "rgb(0,153,0)",
-            "rgb(0,204,0)",
-            "rgb(0,255,0)",
-        ],
+        styles=None,
     ):
         """
         Color a value based on where it falls within a range
         """
+        if styles is None:
+            styles = [  # shades in red, yellow, and green
+                "rgb(51,0,0)",
+                "rgb(102,0,0)",
+                "rgb(153,0,0)",
+                "rgb(204,0,0)",
+                "rgb(255,0,0)",
+                "rgb(51,51,0)",
+                "rgb(102,102,0)",
+                "rgb(153,153,0)",
+                "rgb(204,204,0)",
+                "rgb(255,255,0)",
+                "rgb(0,51,0)",
+                "rgb(0,102,0)",
+                "rgb(0,153,0)",
+                "rgb(0,204,0)",
+                "rgb(0,255,0)",
+            ]
         index_percent = (value - minimum) / (maximum - minimum)
         if log:
             index_percent = math.log(1 + index_percent, 2)

--- a/lair/sessions/__init__.py
+++ b/lair/sessions/__init__.py
@@ -1,17 +1,22 @@
 from .openai_chat_session import OpenAIChatSession
-from .session_manager import SessionManager, UnknownSessionException
+from .session_manager import (
+    SessionManager,
+    UnknownSessionError,
+    UnknownSessionException,
+)
 
 
 def get_chat_session(session_type, *args, **kwargs):
     if session_type == "openai_chat":
         return OpenAIChatSession(*args, **kwargs)
     else:
-        raise ValueError("Unknown session type: %s" % session_type)
+        raise ValueError(f"Unknown session type: {session_type}")
 
 
 __all__ = [
     "OpenAIChatSession",
     "SessionManager",
+    "UnknownSessionError",
     "UnknownSessionException",
     "get_chat_session",
 ]

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,17 +1,17 @@
 import datetime
 import json
 import os
-import zoneinfo
 from typing import Any, Dict, List, Optional, cast
 
 import openai
+import zoneinfo
 
 import lair
 import lair.reporting
-from lair.logging import logger
-
 from lair.components.history import ChatHistory
 from lair.components.tools import ToolSet
+from lair.logging import logger
+
 from .base_chat_session import BaseChatSession
 
 
@@ -24,7 +24,10 @@ class OpenAIChatSession(BaseChatSession):
         lair.events.subscribe("config.update", lambda d: self.recreate_openai_client(), instance=self)
 
     def _get_openai_client(self):
-        logger.debug("Create OpenAI() client: base_url=%s" % lair.config.get("openai.api_base"))
+        logger.debug(
+            "Create OpenAI() client: base_url=%s",
+            lair.config.get("openai.api_base"),
+        )
         self.openai = openai.OpenAI(
             api_key=os.environ.get(lair.config.get("openai.api_key_environment_variable")) or "none",
             base_url=lair.config.get("openai.api_base"),
@@ -56,7 +59,8 @@ class OpenAIChatSession(BaseChatSession):
 
         model_name = lair.config.get("model.name")
         logger.debug(f"OpenAIChatSession(): completions.create(model={model_name}, len(messages)={len(messages)})")
-        assert self.openai is not None
+        if self.openai is None:
+            raise RuntimeError("OpenAI client is not initialized")
         answer = self.openai.chat.completions.create(
             messages=cast(Any, messages),
             model=model_name,
@@ -114,10 +118,13 @@ class OpenAIChatSession(BaseChatSession):
         cycle = 0
         while True:
             logger.debug(
-                "OpenAIChatSession(): completions.create(model=%s, len(messages)=%d), cycle=%d"
-                % (lair.config.get("model.name"), len(messages), cycle)
+                "OpenAIChatSession(): completions.create(model=%s, len(messages)=%d), cycle=%d",
+                lair.config.get("model.name"),
+                len(messages),
+                cycle,
             )
-            assert self.openai is not None
+            if self.openai is None:
+                raise RuntimeError("OpenAI client is not initialized")
             answer = self.openai.chat.completions.create(
                 messages=cast(Any, messages),
                 model=lair.config.get("model.name"),
@@ -165,7 +172,8 @@ class OpenAIChatSession(BaseChatSession):
         """
         try:
             models: List[Dict[str, Any]] = []
-            assert self.openai is not None
+            if self.openai is None:
+                raise RuntimeError("OpenAI client is not initialized")
             for model in self.openai.models.list():
                 models.append(
                     {

--- a/lair/sessions/serializer.py
+++ b/lair/sessions/serializer.py
@@ -49,7 +49,7 @@ def update_session_from_dict(chat_session, state):
 
 
 def load(chat_session, filename):
-    with open(filename, "r") as state_file:
+    with open(filename) as state_file:
         contents = state_file.read()
         state = json.loads(contents)
 

--- a/lair/sessions/session_manager.py
+++ b/lair/sessions/session_manager.py
@@ -1,23 +1,25 @@
+import importlib
 import json
 import os
-
-import importlib
 from typing import Any
-
-lmdb: Any = importlib.import_module("lmdb")
 
 import lair
 import lair.sessions.serializer
 import lair.util
 from lair.logging import logger
 
+lmdb: Any = importlib.import_module("lmdb")
+
 # For clarity:
 #   A `chat_session` is a ChatSession object
 #   A `session` is a serialized session dict from lair.sessions.serializer
 
 
-class UnknownSessionException(Exception):
+class UnknownSessionError(Exception):
     pass
+
+# Backwards compatibility for older test imports
+UnknownSessionException = UnknownSessionError
 
 
 class SessionManager:
@@ -79,14 +81,14 @@ class SessionManager:
                     return int(id_or_alias)
 
         if raise_exception:
-            raise UnknownSessionException(f"Unknown session: {id_or_alias}")
+            raise UnknownSessionError(f"Unknown session: {id_or_alias}")
         else:
             return None
 
     def all_sessions(self):
         with self.env.begin() as txn:
             cursor = txn.cursor()
-            prefix = "session:".encode()
+            prefix = b"session:"
             if cursor.set_range(prefix):
                 for key, value in cursor:
                     if not key.startswith(prefix):
@@ -206,7 +208,7 @@ class SessionManager:
         try:
             if self.get_session_id(alias):
                 return False
-        except UnknownSessionException:
+        except UnknownSessionError:
             return True
 
     def set_alias(self, id_or_alias, new_alias):

--- a/lair/util/argparse.py
+++ b/lair/util/argparse.py
@@ -1,13 +1,13 @@
 import argparse
 
 
-class ArgumentParserExitException(Exception):
+class ArgumentParserExitError(Exception):
     """Custom Exception for argparse to throw on exit, instead of actually exiting"""
 
     pass
 
 
-class ArgumentParserHelpException(Exception):
+class ArgumentParserHelpError(Exception):
     pass
 
 
@@ -22,8 +22,8 @@ class ErrorRaisingArgumentParser(argparse.ArgumentParser):
         """Instead of exiting, throw an exception with the error"""
         if message:
             self._print_message(message)
-        raise ArgumentParserExitException(None, None)
+        raise ArgumentParserExitError(None, None)
 
     def print_help(self, file=None):
         """Override print_help to raise an exception with the help message."""
-        raise ArgumentParserHelpException(self.format_help())
+        raise ArgumentParserHelpError(self.format_help())

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -37,7 +37,7 @@ def safe_int(number):
 
 
 def slurp_file(filename):
-    with open(os.path.expanduser(filename), "r") as fd:
+    with open(os.path.expanduser(filename)) as fd:
         document = fd.read()
 
     return document
@@ -53,7 +53,7 @@ def parse_yaml_text(text):
 
 
 def parse_yaml_file(filename):
-    with open(filename, "r") as fd:
+    with open(filename) as fd:
         return yaml.safe_load(fd)
 
 
@@ -108,7 +108,7 @@ def expand_filename_list(filenames, *, fail_on_not_found=True, sort_results=True
         matches = glob.glob(os.path.expanduser(filename))
 
         if not matches and fail_on_not_found:
-            raise Exception("File not found: %s" % filename)
+            raise Exception(f"File not found: {filename}")
 
         new_filenames.extend(matches)
 
@@ -188,10 +188,10 @@ def _get_attachments_content__text_file(filename):
             do_truncate = True
 
     try:
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             contents = fd.read(limit if do_truncate else None)
     except UnicodeDecodeError as error:
-        raise Exception(f"File attachment is not text: file={filename}, error={error}")
+        raise Exception(f"File attachment is not text: file={filename}, error={error}") from error
 
     if lair.config.get("misc.provide_attachment_filenames"):
         header = f"User provided file: filename={filename}\n---\n"

--- a/tests/test_argparse_utils.py
+++ b/tests/test_argparse_utils.py
@@ -2,8 +2,8 @@ import argparse
 import pytest
 from lair.util.argparse import (
     ErrorRaisingArgumentParser,
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
 )
 
 
@@ -16,17 +16,17 @@ def test_required_argument_error():
 
 def test_print_help_exception():
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserHelpException):
+    with pytest.raises(ArgumentParserHelpError):
         parser.print_help()
 
 
 def test_exit_exception():
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserExitException):
+    with pytest.raises(ArgumentParserExitError):
         parser.exit()
 
 
 def test_help_flag(monkeypatch):
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserHelpException):
+    with pytest.raises(ArgumentParserHelpError):
         parser.parse_args(["-h"])

--- a/tests/test_chat_commands.py
+++ b/tests/test_chat_commands.py
@@ -28,7 +28,7 @@ def setup_ci(monkeypatch):
             return orig_get(id_or_alias, raise_exception)
         except Exception:
             if raise_exception:
-                raise lair.sessions.session_manager.UnknownSessionException("Unknown")
+                raise lair.sessions.session_manager.UnknownSessionError("Unknown")
             return None
 
     monkeypatch.setattr(ci.session_manager, "get_session_id", patched_get)

--- a/tests/test_chat_interface_commands_extra.py
+++ b/tests/test_chat_interface_commands_extra.py
@@ -283,8 +283,8 @@ def test_last_prompt_and_response(monkeypatch, caplog):
 def test_list_settings_help(monkeypatch):
     ci = make_ci()
     monkeypatch.setattr(commands, "ErrorRaisingArgumentParser", commands.ErrorRaisingArgumentParser)
-    monkeypatch.setattr(commands, "ArgumentParserHelpException", commands.ArgumentParserHelpException)
-    monkeypatch.setattr(commands, "ArgumentParserExitException", commands.ArgumentParserExitException)
+    monkeypatch.setattr(commands, "ArgumentParserHelpError", commands.ArgumentParserHelpError)
+    monkeypatch.setattr(commands, "ArgumentParserExitError", commands.ArgumentParserExitError)
     result = []
     monkeypatch.setattr(ci.reporting, "system_message", lambda m, **k: result.append(m))
     ci.command_list_settings("/list-settings", [], "--help")

--- a/tests/test_chat_interface_more.py
+++ b/tests/test_chat_interface_more.py
@@ -108,7 +108,7 @@ def test_handle_session_switch(monkeypatch):
 
     def fake_switch(id_or_alias, chat_session):
         if id_or_alias == "unknown":
-            raise lair.sessions.UnknownSessionException("Unknown")
+            raise lair.sessions.UnknownSessionError("Unknown")
         return original(id_or_alias, chat_session)
 
     monkeypatch.setattr(ci.session_manager, "switch_to_session", fake_switch)

--- a/tests/test_chat_interface_new.py
+++ b/tests/test_chat_interface_new.py
@@ -14,7 +14,7 @@ def setup_interface(monkeypatch):
 def test_init_starting_session_create(monkeypatch):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: True)
     ci.chat_session.session_alias = None
@@ -26,7 +26,7 @@ def test_init_starting_session_create(monkeypatch):
 def test_init_starting_session_integer_error(monkeypatch, caplog):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: False)
     monkeypatch.setattr(lair.util, "safe_int", int)


### PR DESCRIPTION
## Summary
- fix ruff lint violations across modules and tests
- modernize string formatting and add explicit exception chaining
- fix open mode usage and cleanup imports
- update tests for renamed exceptions

## Testing
- `python -m compileall -q lair`
- `poetry run ruff check lair`
- `poetry run ruff format lair`
- `poetry run mypy lair`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68788de2cd6c8320805c227a17813b17