### PR TITLE
Fix ruff UP031 and related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - tests: Add coverage for comfy_caller workflows
 - util: replace deprecated importlib.resources API
 - cli: avoid runtime warnings when no event loop is present
+- cli: update modules for new ruff checks
 
 ### New Features
 - comfy: Add `outpaint` workflow for extending images

--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -407,7 +407,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                 self.commands[command]["callback"](command, arguments, arguments_str)
                 return True
             except Exception as error:
-                self.reporting.error("Command failed: %s" % error)
+                self.reporting.error(f"Command failed: {error}")
                 return False
         else:
             self.reporting.user_error("Unknown command")
@@ -454,7 +454,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
             else:
                 return self._handle_request_chat(request)
         except Exception as error:
-            self.reporting.error("Chat failed: %s" % error)
+            self.reporting.error(f"Chat failed: {error}")
             return False
 
     def startup_message(self):
@@ -512,9 +512,9 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
     def _generate_toolbar_template_flags(self):
         def flag(character, parameter):
             if lair.config.active[parameter]:
-                return "<flag.on>%s</flag.on>" % character.upper()
+                return f"<flag.on>{character.upper()}</flag.on>"
             else:
-                return "<flag.off>%s</flag.off>" % character.lower()
+                return f"<flag.off>{character.lower()}</flag.off>"
 
         return (
             flag("l", "chat.multiline_input")
@@ -531,7 +531,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
         if time.time() < self.flash_message_expiration:
             return prompt_toolkit.formatted_text.HTML(
-                "<bottom-toolbar.flash>%s</bottom-toolbar.flash>" % self.flash_message
+                f"<bottom-toolbar.flash>{self.flash_message}</bottom-toolbar.flash>"
             )
 
         try:
@@ -541,7 +541,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
             return prompt_toolkit.formatted_text.HTML(template)
         except Exception as error:
-            logger.error("Unable to render toolbar: %s" % error)
+            logger.error(f"Unable to render toolbar: {error}")
             logger.error("Disabling toolbar")
             lair.config.active["chat.enable_toolbar"] = False
             return ""

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -227,7 +227,7 @@ class ChatInterfaceCommands:
                         lair.util.save_file(filename, response + "\n")
                         self.reporting.system_message(f"Section saved  ({len(response)} bytes)")
                     else:
-                        print(response)
+                        self.reporting.print_rich(response)
                 else:
                     logger.error("Extract failed: No matching section found")
             else:
@@ -255,10 +255,7 @@ class ChatInterfaceCommands:
 
             if edited_jsonl_str is not None:
                 try:
-                    if not edited_jsonl_str.strip():
-                        new_messages = []
-                    else:
-                        new_messages = lair.util.decode_jsonl(edited_jsonl_str)
+                    new_messages = [] if not edited_jsonl_str.strip() else lair.util.decode_jsonl(edited_jsonl_str)
                 except Exception as error:
                     logger.error(f"Failed to decode edited history JSONL: {error}")
                     return
@@ -485,6 +482,6 @@ class ChatInterfaceCommands:
             key = arguments[0]
             value = "" if len(arguments) == 1 else arguments_str[len(arguments[0]) + 1 :].strip()
             if key not in lair.config.active:
-                self.reporting.user_error("ERROR: Unknown key: %s" % key)
+                self.reporting.user_error(f"ERROR: Unknown key: {key}")
             else:
                 lair.config.set(key, value)

--- a/lair/cli/chat_interface_completer.py
+++ b/lair/cli/chat_interface_completer.py
@@ -59,7 +59,7 @@ class ChatInterfaceCompleter(Completer):
             yield Completion(f"/set {key} {value}", display=value, start_position=-len(text))
 
     def _get_set_key_completion(self, prefix, text):
-        for key in lair.config.active.keys():
+        for key in lair.config.active:
             if key.startswith("_"):
                 continue
             if key.startswith(prefix) and prefix != key:

--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -3,9 +3,9 @@ import sys
 import traceback
 
 import lair.logging
-import lair.util
 import lair.module_loader
 import lair.reporting
+import lair.util
 from lair.logging import logger
 
 
@@ -25,7 +25,7 @@ def init_subcommands(parent_parser):
             for alias in aliases:
                 commands[alias] = commands[name]
         except Exception as error:
-            raise Exception("Failed to load module '%s': %s" % (name, error))
+            raise Exception(f"Failed to load module '{name}': {error}") from error
 
     return commands
 
@@ -34,9 +34,9 @@ def parse_arguments():
     class HelpFormatter(argparse.HelpFormatter):
         def _format_action(self, action):
             if type(action) is argparse._SubParsersAction._ChoicesPseudoAction:
-                return "  %-40.40s - %s\n" % (self._format_action_invocation(action), self._expand_help(action))
+                return f"  {self._format_action_invocation(action):<40.40} - {self._expand_help(action)}\n"
             else:
-                return super(HelpFormatter, self)._format_action(action)
+                return super()._format_action(action)
 
     parser = argparse.ArgumentParser(formatter_class=HelpFormatter)
     parser.add_argument("--debug", "-d", action="store_true", default=False, help="Enable debugging output")
@@ -55,7 +55,7 @@ def parse_arguments():
     arguments = parser.parse_args()
 
     if arguments.version:
-        print(f"Lair v{lair.version()}")
+        sys.stdout.write(f"Lair v{lair.version()}\n")
         sys.exit(0)
     elif not arguments.subcommand:
         parser.print_help()
@@ -102,7 +102,7 @@ def start():
     except KeyboardInterrupt:
         sys.exit("Received interrupt.  Exiting")
     except Exception as error:
-        logger.error("An error has occurred: (%s)\n" % error)
+        logger.error(f"An error has occurred: ({error})\n")
         if "arguments" not in locals() or lair.util.is_debug_enabled():
             traceback.print_exc()
             sys.exit(1)

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -115,11 +115,11 @@ class ComfyCaller:
         # this, STDOUT is ignored on import.
         with contextlib.redirect_stdout(io.StringIO()):
             runtime_module = importlib.import_module("comfy_script.runtime")
-            load = getattr(runtime_module, "load")
-            Workflow_local = getattr(runtime_module, "Workflow")
+            load = runtime_module.load
+            workflow_local = runtime_module.Workflow
 
             globals()["load"] = load
-            globals()["Workflow"] = Workflow_local
+            globals()["Workflow"] = workflow_local
 
             if lair.config.get("comfy.verify_ssl") is False:
                 self._monkey_patch_comfy_script()
@@ -185,7 +185,7 @@ class ComfyCaller:
             with open(image, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode("utf-8")
         else:
-            raise ValueError("Conversion of image to base64 not supported for type: %s" % type(image))
+            raise ValueError(f"Conversion of image to base64 not supported for type: {type(image)}")
 
     def _ensure_watch_thread(self):
         runtime = importlib.import_module("comfy_script.runtime")
@@ -482,9 +482,9 @@ class ComfyCaller:
             prompt = StringFunctionPysssss("append", "no", prompt, auto_prompt_extra, auto_prompt_suffix)
 
         prompts = []
-        for prompt in prompt.wait()._output["text"]:
+        for text in prompt.wait()._output["text"]:
             # Encoding is used so that the save file bytes() support can write the output
-            prompts.append(prompt.encode())
+            prompts.append(text.encode())
 
         return prompts
 

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -71,7 +71,7 @@ class ChatHistory:
         if role == "tool":
             raise ValueError("add_message(): Role of tool is invalid. Use add_tool_message()")
         elif role not in self.ALLOWED_ROLES:
-            raise ValueError("add_message(): Unknown role: %s" % role)
+            raise ValueError(f"add_message(): Unknown role: {role}")
 
         self._history.append(
             {

--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -127,4 +127,4 @@ def validate_messages(messages):
         else:
             error_location = "root"
 
-        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}")
+        raise jsonschema.ValidationError(f"Validation failed at '{error_location}': {error.message}") from error

--- a/lair/components/tools/__init__.py
+++ b/lair/components/tools/__init__.py
@@ -33,7 +33,7 @@ def get_tool_classes_from_str(tool_names_str):
         name = name.strip()
 
         if name not in TOOLS:
-            raise ValueError("Unknown tool name: %s" % tool_names_str)
+            raise ValueError(f"Unknown tool name: {tool_names_str}")
 
         classes.append(TOOLS[name])
 

--- a/lair/components/tools/file_tool.py
+++ b/lair/components/tools/file_tool.py
@@ -148,10 +148,7 @@ class FileTool:
         try:
             workspace = os.path.abspath(lair.config.get("tools.file.path"))
 
-            if not os.path.isabs(path):
-                pattern = os.path.join(workspace, path)
-            else:
-                pattern = path
+            pattern = os.path.join(workspace, path) if not os.path.isabs(path) else path
 
             file_paths = glob.glob(pattern, recursive=True)
             if not file_paths:
@@ -165,7 +162,7 @@ class FileTool:
                 elif not os.path.isfile(file_path):
                     continue  # Skip non-files (e.g., directories)
 
-                with open(file_path, "r") as f:
+                with open(file_path) as f:
                     content = f.read()
                     relative_path = os.path.relpath(file_path, workspace)
                     file_contents[relative_path] = content

--- a/lair/components/tools/python_tool.py
+++ b/lair/components/tools/python_tool.py
@@ -36,9 +36,10 @@ class PythonTool:
                 "name": "run_python",
                 "description": (
                     "Run a python script and return the output. "
-                    "This is not a REPL. Repeat calls are independent. Output must be printed to be retrieved. "
-                    "STDOUT, STDERR are returned.) "
-                    "(extra_modules=%(extra_modules)s, timeout=%(timeout)s)" % settings
+                    "This is not a REPL. Repeat calls are independent. "
+                    "Output must be printed to be retrieved. "
+                    f"STDOUT, STDERR are returned.) (extra_modules={settings['extra_modules']}, "
+                    f"timeout={settings['timeout']})"
                 ),
                 "parameters": {
                     "type": "object",

--- a/lair/components/tools/tmux_tool.py
+++ b/lair/components/tools/tmux_tool.py
@@ -113,7 +113,7 @@ class TmuxTool:
             try:
                 self._connect_to_tmux()
             except Exception as connect_error:
-                raise Exception(f"Tmux server unavailable: {connect_error}")
+                raise Exception(f"Tmux server unavailable: {connect_error}") from connect_error
 
     def _get_output(self, return_mode, *, prune_line=None, window_id=None):
         """

--- a/lair/components/tools/tool_set.py
+++ b/lair/components/tools/tool_set.py
@@ -68,11 +68,7 @@ class ToolSet:
         return enabled_tools
 
     def all_flags_enabled(self, flags):
-        for flag in flags:
-            if not lair.config.get(flag):
-                return False
-
-        return True
+        return all(lair.config.get(flag) for flag in flags)
 
     def get_all_tools(self):
         """


### PR DESCRIPTION
## Summary
- handle errors with f-strings in chat interface
- drop print() usage in `command_extract`
- streamline history editing logic
- simplify config completion loop
- clean up CLI run utilities
- stop using getattr for constants in `comfy_caller`
- update file utilities and tools helpers
- document ruff check fixes in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: ConfigUnknownKeyException naming, ConfigInvalidType naming, etc.)*
- `ruff format lair`
- `mypy lair` *(fails: missing type stubs for several modules)*
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68796f4d4aa08320a2a81fb4ec9460f5