### PR TITLE
Fix ruff lint warnings in tests

### DIFF
--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -407,7 +407,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                 self.commands[command]["callback"](command, arguments, arguments_str)
                 return True
             except Exception as error:
-                self.reporting.error("Command failed: %s" % error)
+                self.reporting.error(f"Command failed: {error}")
                 return False
         else:
             self.reporting.user_error("Unknown command")
@@ -454,7 +454,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
             else:
                 return self._handle_request_chat(request)
         except Exception as error:
-            self.reporting.error("Chat failed: %s" % error)
+            self.reporting.error(f"Chat failed: {error}")
             return False
 
     def startup_message(self):
@@ -512,9 +512,9 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
     def _generate_toolbar_template_flags(self):
         def flag(character, parameter):
             if lair.config.active[parameter]:
-                return "<flag.on>%s</flag.on>" % character.upper()
+                return f"<flag.on>{character.upper()}</flag.on>"
             else:
-                return "<flag.off>%s</flag.off>" % character.lower()
+                return f"<flag.off>{character.lower()}</flag.off>"
 
         return (
             flag("l", "chat.multiline_input")
@@ -531,7 +531,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
         if time.time() < self.flash_message_expiration:
             return prompt_toolkit.formatted_text.HTML(
-                "<bottom-toolbar.flash>%s</bottom-toolbar.flash>" % self.flash_message
+                f"<bottom-toolbar.flash>{self.flash_message}</bottom-toolbar.flash>"
             )
 
         try:
@@ -541,7 +541,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
             return prompt_toolkit.formatted_text.HTML(template)
         except Exception as error:
-            logger.error("Unable to render toolbar: %s" % error)
+            logger.error(f"Unable to render toolbar: {error}")
             logger.error("Disabling toolbar")
             lair.config.active["chat.enable_toolbar"] = False
             return ""

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -181,7 +181,7 @@ class ChatInterfaceCommands:
         # Other modules can subscribe to chat.init() and then call
         # this function to register their own sub-commands.
         if command in self.commands:
-            raise Exception(f"Failed to register chat command '{command}': Already registered")
+            raise RuntimeError(f"Failed to register chat command '{command}': Already registered")
 
         self.commands[command] = {
             "callback": callback,

--- a/tests/unit/test_argparse_utils.py
+++ b/tests/unit/test_argparse_utils.py
@@ -1,9 +1,11 @@
 import argparse
+
 import pytest
+
 from lair.util.argparse import (
-    ErrorRaisingArgumentParser,
     ArgumentParserExitException,
     ArgumentParserHelpException,
+    ErrorRaisingArgumentParser,
 )
 
 

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -1,7 +1,8 @@
 import argparse
+
+import lair
 import pytest
 from tests.unit.test_chat_interface_extended import make_interface
-import lair
 
 
 # Helpers
@@ -26,9 +27,9 @@ def setup_ci(monkeypatch):
     def patched_get(id_or_alias, raise_exception=True):
         try:
             return orig_get(id_or_alias, raise_exception)
-        except Exception:
+        except Exception as exc:
             if raise_exception:
-                raise lair.sessions.session_manager.UnknownSessionException("Unknown")
+                raise lair.sessions.session_manager.UnknownSessionException("Unknown") from exc
             return None
 
     monkeypatch.setattr(ci.session_manager, "get_session_id", patched_get)

--- a/tests/unit/test_chat_history.py
+++ b/tests/unit/test_chat_history.py
@@ -1,12 +1,11 @@
-import gc
 import copy
+import gc
 
 import pytest
 
 import lair
-from lair.components.history.chat_history import ChatHistory
 from lair.components.history import schema
-from lair.components.history.chat_history import logger
+from lair.components.history.chat_history import ChatHistory, logger
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_chat_interface.py
+++ b/tests/unit/test_chat_interface.py
@@ -1,15 +1,19 @@
-import sys
-import types
 import importlib
-import shutil
-import time
 import os
-import pytest
+import shutil
+import sys
+import time
+import types
+
 import prompt_toolkit
+import pytest
+
 import lair
 from lair.components.history.chat_history import ChatHistory
 from lair.logging import logger
-from tests.unit.test_chat_interface_extended import make_interface as extended_make_interface
+from tests.unit.test_chat_interface_extended import (
+    make_interface as extended_make_interface,
+)
 
 
 def import_commands():
@@ -276,11 +280,7 @@ def test_generate_toolbar_flags_and_prompt(monkeypatch):
     ci.chat_session.session_alias = "al"
     flags = ci._generate_toolbar_template_flags()
     assert flags == (
-        "<flag.on>L</flag.on>"
-        "<flag.off>m</flag.off>"
-        "<flag.on>T</flag.on>"
-        "<flag.off>v</flag.off>"
-        "<flag.on>W</flag.on>"
+        "<flag.on>L</flag.on><flag.off>m</flag.off><flag.on>T</flag.on><flag.off>v</flag.off><flag.on>W</flag.on>"
     )
     prompt = ci._generate_prompt()
     assert f"{ci.chat_session.session_id}:al" in prompt.value

--- a/tests/unit/test_chat_interface_commands.py
+++ b/tests/unit/test_chat_interface_commands.py
@@ -1,11 +1,11 @@
-import types
-import sys
+import importlib
 import re
+import sys
+import types
 from contextlib import contextmanager
 
 import pytest
 
-import importlib
 import lair
 
 
@@ -88,7 +88,7 @@ class DummyChatSession:
         pass
 
 
-class UnknownSessionException(Exception):
+class UnknownSessionError(Exception):
     pass
 
 
@@ -106,7 +106,7 @@ class DummySessionManager:
             if id_or_alias in self.aliases:
                 return self.aliases[id_or_alias]
         if raise_exception:
-            raise UnknownSessionException("Unknown")
+            raise UnknownSessionError("Unknown")
         return None
 
     def is_alias_available(self, alias):
@@ -182,7 +182,7 @@ class DummyCI(commands.ChatInterfaceCommands):
 @pytest.fixture(autouse=True)
 def patch_unknown(monkeypatch):
     dummy_mod = types.ModuleType("lair.sessions.session_manager")
-    dummy_mod.UnknownSessionException = UnknownSessionException
+    dummy_mod.UnknownSessionException = UnknownSessionError
     sys.modules["lair.sessions.session_manager"] = dummy_mod
     yield
     sys.modules.pop("lair.sessions.session_manager", None)
@@ -196,7 +196,7 @@ def test_register_command_duplicate():
     ci = make_ci()
     ci.register_command("/t", lambda *a: None, "d")
     assert "/t" in ci.commands
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         ci.register_command("/t", lambda *a: None, "d")
 
 

--- a/tests/unit/test_chat_interface_reports.py
+++ b/tests/unit/test_chat_interface_reports.py
@@ -1,9 +1,10 @@
 # ruff: noqa: E402
 import sys
+import types
 
 sys.modules.pop("pdfplumber", None)
 import pdfplumber  # noqa: F401,E402
-import types
+
 import lair
 from lair.cli.chat_interface_reports import ChatInterfaceReports
 from lair.logging import logger

--- a/tests/unit/test_cli_args.py
+++ b/tests/unit/test_cli_args.py
@@ -1,6 +1,6 @@
+import importlib
 import sys
 import types
-import importlib
 from unittest import mock
 
 import lair
@@ -63,9 +63,8 @@ def test_parse_arguments_version(monkeypatch, capsys):
     monkeypatch.setattr(run, "init_subcommands", lambda parser: {})
     monkeypatch.setattr(lair, "version", lambda: "1.2.3")
     argv = ["prog", "--version"]
-    with pytest.raises(SystemExit) as exc:
-        with mock.patch.object(sys, "argv", argv):
-            run.parse_arguments()
+    with pytest.raises(SystemExit) as exc, mock.patch.object(sys, "argv", argv):
+        run.parse_arguments()
     assert exc.value.code == 0
     captured = capsys.readouterr()
     assert "1.2.3" in captured.out
@@ -87,7 +86,6 @@ def test_set_config_from_arguments_bad(monkeypatch):
 def test_parse_arguments_no_subcommand(monkeypatch):
     monkeypatch.setattr(run, "init_subcommands", fake_init)
     argv = ["prog"]
-    with pytest.raises(SystemExit) as exc:
-        with mock.patch.object(sys, "argv", argv):
-            run.parse_arguments()
+    with pytest.raises(SystemExit) as exc, mock.patch.object(sys, "argv", argv):
+        run.parse_arguments()
     assert exc.value.code == 1

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -1,6 +1,7 @@
+import importlib
 import sys
 import types
-import importlib
+
 import click
 from click.testing import CliRunner
 
@@ -26,6 +27,8 @@ def test_cli_runner_chat_command(monkeypatch):
         monkeypatch.setitem(sys.modules, name, mod)
 
     import lair.reporting  # ensure submodule is registered
+
+    assert lair.reporting  # make linter happy
 
     run = importlib.import_module("lair.cli.run")
 


### PR DESCRIPTION
## Summary
- fix import ordering across tests
- modernize raising patterns and clarify custom exceptions
- simplify CLI tests and avoid subprocess usage
- refactor extended chat interface test helpers
- tweak runtime errors in chat interface commands

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests` *(fails: Found 159 errors)*
- `ruff format lair tests`
- `mypy lair` *(fails: Found 29 errors)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6879710b62e883208d2f9b02baf171b3