### PR TITLE
Fix tests and lint

### DIFF
--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -87,7 +87,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
         if id_or_alias:
             try:
                 self._switch_to_session(id_or_alias)
-            except lair.sessions.UnknownSessionException:
+            except lair.sessions.UnknownSessionError:
                 if create_session_if_missing:
                     if not self.session_manager.is_alias_available(id_or_alias):
                         if isinstance(lair.util.safe_int(id_or_alias), int):
@@ -309,8 +309,8 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                             When False, it logs an error instead.
 
         Raises:
-          lair.sessions.UnknownSessionException: If the session ID is unknown
-                                                 and `raise_exceptions` is True.
+          lair.sessions.UnknownSessionError: If the session ID is unknown
+                                             and `raise_exceptions` is True.
         """
         try:
             with lair.events.defer_events():
@@ -319,7 +319,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
                 self._rebuild_chat_session()
                 if old_session_id != self.chat_session.session_id:
                     self.last_used_session_id = old_session_id
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             if raise_exceptions:
                 raise
             else:
@@ -361,7 +361,7 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
 
         try:
             self._switch_to_session(id_or_alias)
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             self.reporting.user_error(f"ERROR: Unknown session: {id_or_alias}")
 
     def _handle_session_set_alias(self):

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -5,8 +5,8 @@ import shlex
 import lair
 from lair.logging import logger
 from lair.util.argparse import (
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
     ErrorRaisingArgumentParser,
 )
 
@@ -330,10 +330,10 @@ class ChatInterfaceCommands:
 
         try:
             new_arguments = parser.parse_args(shlex.split(arguments_str))
-        except ArgumentParserHelpException as error:  # Display help with styles
+        except ArgumentParserHelpError as error:  # Display help with styles
             self.reporting.system_message(str(error), disable_markdown=True)
             return
-        except ArgumentParserExitException:  # Ignore exits
+        except ArgumentParserExitError:  # Ignore exits
             return
 
         self.print_config_report(
@@ -453,7 +453,7 @@ class ChatInterfaceCommands:
             # If the current session was deleted, recreate it
             try:
                 self.session_manager.get_session_id(self.chat_session.session_id)
-            except lair.sessions.session_manager.UnknownSessionException:
+            except lair.sessions.session_manager.UnknownSessionError:
                 self._new_chat_session()
 
     def command_session_new(self, command, arguments, arguments_str):

--- a/lair/modules/comfy.py
+++ b/lair/modules/comfy.py
@@ -11,8 +11,8 @@ import lair.cli
 import lair.comfy_caller
 from lair.logging import logger  # noqa
 from lair.util.argparse import (
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
     ErrorRaisingArgumentParser,
 )
 
@@ -511,10 +511,10 @@ class Comfy:
                 try:
                     params = chat_command_parser.parse_args(new_arguments)
                     params.comfy_url = lair.config.get("comfy.url")
-                except ArgumentParserHelpException as error:  # Display help with styles
+                except ArgumentParserHelpError as error:  # Display help with styles
                     chat_interface.reporting.error(str(error), show_exception=False)
                     return
-                except ArgumentParserExitException:  # Ignore exits
+                except ArgumentParserExitError:  # Ignore exits
                     return
             except argparse.ArgumentError as error:
                 message = str(error)

--- a/lair/modules/util.py
+++ b/lair/modules/util.py
@@ -125,7 +125,7 @@ class Util:
         session_manager = lair.sessions.SessionManager()
         try:
             session_manager.switch_to_session(arguments.session, chat_session)
-        except lair.sessions.UnknownSessionException:
+        except lair.sessions.UnknownSessionError:
             if not arguments.allow_create_session:
                 logger.error(f"Unknown session: {arguments.session}")
                 sys.exit(1)

--- a/lair/sessions/__init__.py
+++ b/lair/sessions/__init__.py
@@ -1,5 +1,5 @@
 from .openai_chat_session import OpenAIChatSession
-from .session_manager import SessionManager, UnknownSessionException
+from .session_manager import SessionManager, UnknownSessionError
 
 
 def get_chat_session(session_type, *args, **kwargs):
@@ -12,6 +12,6 @@ def get_chat_session(session_type, *args, **kwargs):
 __all__ = [
     "OpenAIChatSession",
     "SessionManager",
-    "UnknownSessionException",
+    "UnknownSessionError",
     "get_chat_session",
 ]

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
-import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
+import zoneinfo
 
 import lair
 import lair.reporting

--- a/lair/sessions/serializer.py
+++ b/lair/sessions/serializer.py
@@ -49,7 +49,7 @@ def update_session_from_dict(chat_session, state):
 
 
 def load(chat_session, filename):
-    with open(filename, "r") as state_file:
+    with open(filename) as state_file:
         contents = state_file.read()
         state = json.loads(contents)
 

--- a/lair/sessions/session_manager.py
+++ b/lair/sessions/session_manager.py
@@ -1,22 +1,21 @@
+import importlib
 import json
 import os
-
-import importlib
 from typing import Any
-
-lmdb: Any = importlib.import_module("lmdb")
 
 import lair
 import lair.sessions.serializer
 import lair.util
 from lair.logging import logger
 
+lmdb: Any = importlib.import_module("lmdb")
+
 # For clarity:
 #   A `chat_session` is a ChatSession object
 #   A `session` is a serialized session dict from lair.sessions.serializer
 
 
-class UnknownSessionException(Exception):
+class UnknownSessionError(Exception):
     pass
 
 
@@ -79,14 +78,14 @@ class SessionManager:
                     return int(id_or_alias)
 
         if raise_exception:
-            raise UnknownSessionException(f"Unknown session: {id_or_alias}")
+            raise UnknownSessionError(f"Unknown session: {id_or_alias}")
         else:
             return None
 
     def all_sessions(self):
         with self.env.begin() as txn:
             cursor = txn.cursor()
-            prefix = "session:".encode()
+            prefix = b"session:"
             if cursor.set_range(prefix):
                 for key, value in cursor:
                     if not key.startswith(prefix):
@@ -206,7 +205,7 @@ class SessionManager:
         try:
             if self.get_session_id(alias):
                 return False
-        except UnknownSessionException:
+        except UnknownSessionError:
             return True
 
     def set_alias(self, id_or_alias, new_alias):

--- a/lair/util/argparse.py
+++ b/lair/util/argparse.py
@@ -1,13 +1,13 @@
 import argparse
 
 
-class ArgumentParserExitException(Exception):
+class ArgumentParserExitError(Exception):
     """Custom Exception for argparse to throw on exit, instead of actually exiting"""
 
     pass
 
 
-class ArgumentParserHelpException(Exception):
+class ArgumentParserHelpError(Exception):
     pass
 
 
@@ -22,8 +22,8 @@ class ErrorRaisingArgumentParser(argparse.ArgumentParser):
         """Instead of exiting, throw an exception with the error"""
         if message:
             self._print_message(message)
-        raise ArgumentParserExitException(None, None)
+        raise ArgumentParserExitError(None, None)
 
     def print_help(self, file=None):
         """Override print_help to raise an exception with the help message."""
-        raise ArgumentParserHelpException(self.format_help())
+        raise ArgumentParserHelpError(self.format_help())

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import glob
-from importlib import resources
 import json
 import logging
 import mimetypes
@@ -11,6 +10,7 @@ import re
 import shlex
 import subprocess
 import tempfile
+from importlib import resources
 from typing import Optional
 
 import pdfplumber
@@ -37,7 +37,7 @@ def safe_int(number):
 
 
 def slurp_file(filename):
-    with open(os.path.expanduser(filename), "r") as fd:
+    with open(os.path.expanduser(filename)) as fd:
         document = fd.read()
 
     return document
@@ -53,7 +53,7 @@ def parse_yaml_text(text):
 
 
 def parse_yaml_file(filename):
-    with open(filename, "r") as fd:
+    with open(filename) as fd:
         return yaml.safe_load(fd)
 
 
@@ -192,10 +192,10 @@ def _get_attachments_content__text_file(filename):
             do_truncate = True
 
     try:
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             contents = fd.read(limit if do_truncate else None)
     except UnicodeDecodeError as error:
-        raise ValueError(f"File attachment is not text: file={filename}, error={error}")
+        raise ValueError(f"File attachment is not text: file={filename}, error={error}") from error
 
     if lair.config.get("misc.provide_attachment_filenames"):
         header = f"User provided file: filename={filename}\n---\n"

--- a/tests/unit/test_argparse_utils.py
+++ b/tests/unit/test_argparse_utils.py
@@ -3,8 +3,8 @@ import argparse
 import pytest
 
 from lair.util.argparse import (
-    ArgumentParserExitException,
-    ArgumentParserHelpException,
+    ArgumentParserExitError,
+    ArgumentParserHelpError,
     ErrorRaisingArgumentParser,
 )
 
@@ -18,17 +18,17 @@ def test_required_argument_error():
 
 def test_print_help_exception():
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserHelpException):
+    with pytest.raises(ArgumentParserHelpError):
         parser.print_help()
 
 
 def test_exit_exception():
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserExitException):
+    with pytest.raises(ArgumentParserExitError):
         parser.exit()
 
 
 def test_help_flag(monkeypatch):
     parser = ErrorRaisingArgumentParser()
-    with pytest.raises(ArgumentParserHelpException):
+    with pytest.raises(ArgumentParserHelpError):
         parser.parse_args(["-h"])

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -1,9 +1,9 @@
 import argparse
 
-import lair
 import pytest
-from tests.unit.test_chat_interface_extended import make_interface
 
+import lair
+from tests.unit.test_chat_interface_extended import make_interface
 
 # Helpers
 
@@ -29,7 +29,7 @@ def setup_ci(monkeypatch):
             return orig_get(id_or_alias, raise_exception)
         except Exception as exc:
             if raise_exception:
-                raise lair.sessions.session_manager.UnknownSessionException("Unknown") from exc
+                raise lair.sessions.session_manager.UnknownSessionError("Unknown") from exc
             return None
 
     monkeypatch.setattr(ci.session_manager, "get_session_id", patched_get)

--- a/tests/unit/test_chat_interface.py
+++ b/tests/unit/test_chat_interface.py
@@ -102,7 +102,7 @@ def test_init_starting_session_alias_used(monkeypatch, caplog):
     monkeypatch.setattr(
         ci,
         "_switch_to_session",
-        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("x")),
+        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("x")),
     )
     with caplog.at_level("ERROR"), pytest.raises(SystemExit):
         ci._init_starting_session("alias", create_session_if_missing=True)
@@ -326,7 +326,7 @@ def test_handle_session_switch(monkeypatch):
 
     def fake_switch(id_or_alias, chat_session):
         if id_or_alias == "unknown":
-            raise lair.sessions.UnknownSessionException("Unknown")
+            raise lair.sessions.UnknownSessionError("Unknown")
         return original(id_or_alias, chat_session)
 
     monkeypatch.setattr(ci.session_manager, "switch_to_session", fake_switch)
@@ -337,7 +337,7 @@ def test_handle_session_switch(monkeypatch):
 def test_init_starting_session_create(monkeypatch):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: True)
     ci.chat_session.session_alias = None
@@ -349,7 +349,7 @@ def test_init_starting_session_create(monkeypatch):
 def test_init_starting_session_integer_error(monkeypatch, caplog):
     ci = setup_interface(monkeypatch)
     monkeypatch.setattr(
-        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u"))
+        ci, "_switch_to_session", lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("u"))
     )
     monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: False)
     monkeypatch.setattr(lair.util, "safe_int", int)
@@ -422,13 +422,13 @@ def test_switch_to_session_unknown(monkeypatch):
     monkeypatch.setattr(
         ci.session_manager,
         "switch_to_session",
-        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("bad")),
+        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionError("bad")),
     )
     captured = []
     monkeypatch.setattr(lair.logging.logger, "error", lambda m: captured.append(m))
     ci._switch_to_session("unknown", raise_exceptions=False)
     assert captured and "Unknown session: unknown" in captured[0]
-    with pytest.raises(lair.sessions.UnknownSessionException):
+    with pytest.raises(lair.sessions.UnknownSessionError):
         ci._switch_to_session("unknown", raise_exceptions=True)
 
 

--- a/tests/unit/test_chat_interface_commands.py
+++ b/tests/unit/test_chat_interface_commands.py
@@ -283,8 +283,8 @@ def test_last_prompt_and_response(monkeypatch, caplog):
 def test_list_settings_help(monkeypatch):
     ci = make_ci()
     monkeypatch.setattr(commands, "ErrorRaisingArgumentParser", commands.ErrorRaisingArgumentParser)
-    monkeypatch.setattr(commands, "ArgumentParserHelpException", commands.ArgumentParserHelpException)
-    monkeypatch.setattr(commands, "ArgumentParserExitException", commands.ArgumentParserExitException)
+    monkeypatch.setattr(commands, "ArgumentParserHelpError", commands.ArgumentParserHelpError)
+    monkeypatch.setattr(commands, "ArgumentParserExitError", commands.ArgumentParserExitError)
     result = []
     monkeypatch.setattr(ci.reporting, "system_message", lambda m, **k: result.append(m))
     ci.command_list_settings("/list-settings", [], "--help")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,33 +1,30 @@
 import contextlib
+import importlib
 import io
 import sys
+import types
 from types import SimpleNamespace
 
-STUB_SCRIPT = """
-import sys, types
-for name in [
-    'lair.cli.chat_interface', 'openai', 'requests', 'trafilatura', 'PIL',
-    'diffusers', 'transformers', 'torch', 'comfy_script', 'lair.comfy_caller'
-]:
-    mod = types.ModuleType(name)
-    if name == 'lair.cli.chat_interface':
-        mod.ChatInterface = object
-    sys.modules[name] = mod
-import lair.cli.run as run
+STUB_MODULES = [
+    "lair.cli.chat_interface",
+    "openai",
+    "requests",
+    "trafilatura",
+    "PIL",
+    "diffusers",
+    "transformers",
+    "torch",
+    "comfy_script",
+    "lair.comfy_caller",
+]
+
+
 class Dummy:
     def __init__(self, parser):
         pass
+
     def run(self, args):
         pass
-
-def fake_init_subcommands(parser):
-    sub = parser.add_subparsers(dest='subcommand')
-    chat_parser = sub.add_parser('chat', help='Chat interface')
-    chat_parser.add_argument('--allow-create-session', action='store_true')
-    return {'chat': Dummy(chat_parser)}
-run.init_subcommands = fake_init_subcommands
-run.start()
-"""
 
 
 def run_command(*args):
@@ -35,7 +32,23 @@ def run_command(*args):
     sys.argv = ["cli", *args]
     buffer = io.StringIO()
     with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
-        exec(STUB_SCRIPT, {})
+        for name in STUB_MODULES:
+            mod = types.ModuleType(name)
+            if name == "lair.cli.chat_interface":
+                mod.ChatInterface = object
+            sys.modules[name] = mod
+
+        import lair.cli.run as run_mod
+
+        def fake_init_subcommands(parser):
+            sub = parser.add_subparsers(dest="subcommand")
+            chat_parser = sub.add_parser("chat", help="Chat interface")
+            chat_parser.add_argument("--allow-create-session", action="store_true")
+            return {"chat": Dummy(chat_parser)}
+
+        run_mod.init_subcommands = fake_init_subcommands
+        run_mod.start()
+        importlib.reload(run_mod)
     sys.argv = argv_backup
     return SimpleNamespace(stdout=buffer.getvalue(), returncode=0)
 

--- a/tests/unit/test_cli_args.py
+++ b/tests/unit/test_cli_args.py
@@ -3,8 +3,9 @@ import sys
 import types
 from unittest import mock
 
-import lair
 import pytest
+
+import lair
 
 
 def import_run():

--- a/tests/unit/test_modules.py
+++ b/tests/unit/test_modules.py
@@ -112,7 +112,7 @@ class DummySessionManager:
 
     def switch_to_session(self, alias, chat_session):
         if self.raise_unknown:
-            raise lair.sessions.UnknownSessionException("no session")
+            raise lair.sessions.UnknownSessionError("no session")
         self.switched = True
 
     def is_alias_available(self, alias):

--- a/tests/unit/test_openai_chat_session.py
+++ b/tests/unit/test_openai_chat_session.py
@@ -1,10 +1,11 @@
-import types
 import importlib
-import sys
-import lair
-
 import json
+import sys
+import types
+
 import pytest
+
+import lair
 
 
 def setup_session(monkeypatch, responses=None, tool_set=None):

--- a/tests/unit/test_python_tool.py
+++ b/tests/unit/test_python_tool.py
@@ -1,5 +1,6 @@
 import subprocess
 import types
+
 import lair
 from lair.components.tools.python_tool import PythonTool
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,12 +1,13 @@
-import builtins
 import datetime
 import traceback
 
+import pytest
 import rich
 import rich.text
+import rich.traceback
 
 import lair
-from lair.reporting.reporting import Reporting
+from lair.reporting.reporting import Reporting, ReportingSingletoneMeta
 
 
 def patch_config(monkeypatch, values):
@@ -228,13 +229,6 @@ def test_messages_to_str_and_colors():
     assert r.color_gt_lt(0, center=0) == "gray"
     assert isinstance(r.color_bool(True), rich.text.Text)
     assert isinstance(r.color_bool(False), rich.text.Text)
-
-
-import pytest
-import rich
-import rich.traceback
-
-from lair.reporting.reporting import Reporting, ReportingSingletoneMeta
 
 
 def reset_reporting():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,5 +1,6 @@
 import argparse
 import types
+
 import pytest
 
 import lair

--- a/tests/unit/test_search_tool.py
+++ b/tests/unit/test_search_tool.py
@@ -1,5 +1,4 @@
 import lair
-
 from lair.components.tools.search_tool import SearchTool
 
 

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -1,8 +1,10 @@
 import json
+
+import pytest
+
 import lair
 from lair.components.history import ChatHistory
 from lair.sessions import serializer
-import pytest
 
 
 class DummySession:

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -116,7 +116,7 @@ def test_add_refresh_and_switch(monkeypatch, tmp_path):
     chat.history.messages.append({"role": "assistant", "content": "ok"})
     chat.session_alias = "beta"
     manager.refresh_from_chat_session(chat)
-    with pytest.raises(mod.UnknownSessionException):
+    with pytest.raises(mod.UnknownSessionError):
         manager.get_session_id("alpha")
     assert manager.get_session_id("beta") == 1
 
@@ -149,7 +149,7 @@ def test_next_prev_delete(monkeypatch, tmp_path):
     assert manager.get_previous_session_id(c2.session_id) == 3
 
     manager.delete_sessions([c1.session_id])
-    with pytest.raises(mod.UnknownSessionException):
+    with pytest.raises(mod.UnknownSessionError):
         manager.get_session_id(c1.session_id)
 
     manager.delete_sessions(["all"])
@@ -165,7 +165,7 @@ def test_ensure_map_size_and_get_session_id(monkeypatch, tmp_path):
 
     assert not manager.is_alias_available("123")
     assert manager.get_session_id("missing", raise_exception=False) is None
-    with pytest.raises(mod.UnknownSessionException):
+    with pytest.raises(mod.UnknownSessionError):
         manager.get_session_id("missing")
 
 

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,8 +1,8 @@
+import sys
 import types
 
 import lair
 from lair.sessions.base_chat_session import BaseChatSession
-import sys
 
 
 class DummySession(BaseChatSession):
@@ -44,6 +44,7 @@ def test_openai_list_models(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyOpenAI))
     import importlib
+
     import lair.sessions.openai_chat_session as ocs
 
     importlib.reload(ocs)

--- a/tests/unit/test_sessions_init.py
+++ b/tests/unit/test_sessions_init.py
@@ -1,7 +1,7 @@
 import pytest
+
 import lair
-from lair.sessions import get_chat_session, OpenAIChatSession
-import lair.sessions.openai_chat_session as ocs
+from lair.sessions import OpenAIChatSession, get_chat_session
 
 
 def test_get_chat_session_openai(monkeypatch):

--- a/tests/unit/test_tool_set.py
+++ b/tests/unit/test_tool_set.py
@@ -1,4 +1,5 @@
 import pytest
+
 import lair
 from lair.components.tools.tool_set import ToolSet
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -17,7 +17,7 @@ class DummySessionManager:
     def switch_to_session(self, session, chat_session):
         self.switched = True
         if self.raise_unknown:
-            raise lair.sessions.UnknownSessionException()
+            raise lair.sessions.UnknownSessionError()
 
     def is_alias_available(self, alias):
         return self.alias_available


### PR DESCRIPTION
## Summary
- fix subcommand initialization in CLI tests
- rename internal exceptions to satisfy linter
- clean up import orderings
- handle unicode decoding with chained exception

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests`
- `mypy lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879c18830a883209adcd5a262faf256