### PR TITLE
Fix config inheritance parsing

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,42 @@
+from lair.config import Configuration
+
+
+def create_config(tmp_path, yaml_text):
+    home = tmp_path
+    (home / ".lair").mkdir()
+    (home / ".lair" / "config.yaml").write_text(yaml_text)
+    return str(home)
+
+
+def test_inherit_with_list(tmp_path, monkeypatch):
+    home = create_config(
+        tmp_path,
+        """
+foo:
+  a: 1
+bar:
+  _inherit: [foo]
+  b: 2
+""",
+    )
+    monkeypatch.setenv("HOME", home)
+    config = Configuration()
+    assert config.modes["bar"]["a"] == 1
+    assert config.modes["bar"]["b"] == 2
+
+
+def test_inherit_with_string(tmp_path, monkeypatch):
+    home = create_config(
+        tmp_path,
+        """
+foo:
+  a: 1
+bar:
+  _inherit: "['foo']"
+  b: 2
+""",
+    )
+    monkeypatch.setenv("HOME", home)
+    config = Configuration()
+    assert config.modes["bar"]["a"] == 1
+    assert config.modes["bar"]["b"] == 2


### PR DESCRIPTION
## Summary
- handle string `_inherit` values gracefully
- test configuration inheritance parsing

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b112650848320b12d2d038f8a86be