### PR TITLE
Increase test coverage for chat sessions

### DIFF
--- a/tests/unit/test_base_chat_session.py
+++ b/tests/unit/test_base_chat_session.py
@@ -1,0 +1,96 @@
+import pytest
+
+import lair
+from lair.components.history import ChatHistory
+from lair.components.tools import ToolSet
+from lair.sessions.base_chat_session import BaseChatSession
+
+
+class DummySession(BaseChatSession):
+    def __init__(self):
+        super().__init__(history=ChatHistory(), tool_set=ToolSet(tools=[]))
+        self.invoked = []
+
+    def invoke(self, messages=None, disable_system_prompt=False, model=None, temperature=None):
+        self.invoked.append(("invoke", messages, disable_system_prompt))
+        return "response"
+
+    def invoke_with_tools(self, messages=None, disable_system_prompt=False):
+        self.invoked.append(("tools", messages, disable_system_prompt))
+        return "tool-response", [{"role": "assistant", "content": "tool", "refusal": None, "tool_calls": []}]
+
+    def list_models(self, ignore_errors=False):
+        return []
+
+
+def test_add_message_to_history():
+    session = DummySession()
+    session._add_message_to_history("hello")
+    session._add_message_to_history([{"role": "user", "content": "hi"}])
+    assert [m["content"] for m in session.history.get_messages()] == ["hello", "hi"]
+
+
+def test_invoke_chat_toggle_tools(monkeypatch):
+    session = DummySession()
+    lair.config.set("tools.enabled", False, no_event=True)
+    result, tools = session._invoke_chat()
+    assert result == "response" and tools is None
+    lair.config.set("tools.enabled", True, no_event=True)
+    result, tools = session._invoke_chat()
+    assert result == "tool-response" and tools
+    assert session.invoked[-1][0] == "tools"
+
+
+def test_record_response_commits():
+    session = DummySession()
+    tool_msgs = [{"role": "assistant", "content": "tool", "refusal": None, "tool_calls": []}]
+    session._record_response("answer", tool_msgs)
+    msgs = session.history.get_messages()
+    assert msgs[-1]["content"] == "answer" and session.history.finalized_index == len(msgs)
+
+
+def test_chat_rollback_on_error(monkeypatch):
+    session = DummySession()
+    lair.config.set("tools.enabled", False, no_event=True)
+    monkeypatch.setattr(session, "_invoke_chat", lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+    called = []
+    original = session.history.rollback
+
+    def wrapped():
+        called.append(True)
+        original()
+
+    monkeypatch.setattr(session.history, "rollback", wrapped)
+    with pytest.raises(RuntimeError):
+        session.chat("bad")
+    assert called and session.history.num_messages() == 0
+
+
+def test_auto_generate_title(monkeypatch):
+    session = DummySession()
+    lair.config.set("session.auto_generate_titles.enabled", True, no_event=True)
+    # Fails due to not enough messages
+    assert session.auto_generate_title() is None
+    # Now add messages and succeed
+    session.history.add_message("user", "hi")
+    session.history.add_message("assistant", "hello")
+    monkeypatch.setattr(session, "invoke", lambda **kw: "A Title")
+    assert session.auto_generate_title() == "A Title"
+    assert session.session_title == "A Title"
+
+
+def test_new_and_import_state():
+    s1 = DummySession()
+    s1.session_id = 1
+    s1.session_alias = "alias"
+    s1.session_title = "title"
+    s1.last_prompt = "p"
+    s1.last_response = "r"
+    s1.history.add_message("user", "hi")
+    s2 = DummySession()
+    s2.import_state(s1)
+    assert s2.session_id == 1 and s2.history.get_messages()[0]["content"] == "hi"
+    s1.history.add_message("user", "new")
+    assert len(s2.history.get_messages()) == 1
+    s2.new_session()
+    assert s2.session_id is None and s2.history.num_messages() == 0

--- a/tests/unit/test_openai_chat_session.py
+++ b/tests/unit/test_openai_chat_session.py
@@ -1,0 +1,91 @@
+import importlib
+import json
+import sys
+import types
+
+import lair
+
+
+def setup_openai(monkeypatch, create_fn):
+    class DummyOpenAI:
+        def __init__(self, *a, **k):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=create_fn))
+            self.models = types.SimpleNamespace(list=lambda: [])
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyOpenAI))
+    import lair.sessions.openai_chat_session as ocs
+
+    importlib.reload(ocs)
+    return ocs
+
+
+class DummyMessage:
+    def __init__(self, tool_calls=None, content=""):
+        self.tool_calls = tool_calls or []
+        self.content = content
+
+    def dict(self):
+        return {
+            "role": "assistant",
+            "content": self.content,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in self.tool_calls
+            ],
+        }
+
+
+class DummyToolCall:
+    def __init__(self, id, name, args):
+        self.id = id
+        self.function = types.SimpleNamespace(name=name, arguments=json.dumps(args))
+
+
+class DummyAnswer:
+    def __init__(self, msg):
+        self.choices = [types.SimpleNamespace(message=msg)]
+
+
+def test_process_tool_calls(monkeypatch):
+    def create_fn(*a, **k):
+        pass
+
+    ocs = setup_openai(monkeypatch, create_fn)
+    session = ocs.OpenAIChatSession(history=None, tool_set=None)
+    session.tool_set = types.SimpleNamespace(call_tool=lambda n, a, i: {"v": a["n"]}, get_definitions=lambda: [])
+    records = []
+    session.reporting = types.SimpleNamespace(
+        assistant_tool_calls=lambda m, show_heading=True: records.append("assistant"),
+        tool_message=lambda m, show_heading=True: records.append("tool"),
+        messages_to_str=lambda m: "",
+    )
+    lair.config.set("chat.verbose", True, no_event=True)
+    messages = []
+    tool_messages = []
+    tc = DummyToolCall("1", "func", {"n": 3})
+    msg = DummyMessage([tc])
+    session._process_tool_calls(msg, messages, tool_messages)
+    assert messages and tool_messages and "tool" in records and "assistant" in records
+
+
+def test_invoke_with_tools(monkeypatch):
+    cycle = {"count": 0}
+
+    def create_fn(*, messages, model, temperature, max_completion_tokens, tools):
+        if cycle["count"] == 0:
+            cycle["count"] += 1
+            return DummyAnswer(DummyMessage([DummyToolCall("1", "f", {"x": 2})]))
+        return DummyAnswer(DummyMessage(content="done"))
+
+    ocs = setup_openai(monkeypatch, create_fn)
+    session = ocs.OpenAIChatSession(history=None, tool_set=None)
+    session.tool_set = types.SimpleNamespace(call_tool=lambda n, a, i: {"res": 1}, get_definitions=lambda: [])
+    result, tool_msgs = session.invoke_with_tools()
+    assert result == "done" and tool_msgs[0]["role"] == "assistant"
+    assert session.last_prompt

--- a/tests/unit/test_session_serializer.py
+++ b/tests/unit/test_session_serializer.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from lair.components.history import ChatHistory
+from lair.components.tools import ToolSet
+from lair.sessions import serializer
+from lair.sessions.base_chat_session import BaseChatSession
+
+
+class DummySession(BaseChatSession):
+    def __init__(self):
+        super().__init__(history=ChatHistory(), tool_set=ToolSet(tools=[]))
+
+    def invoke(self, messages=None, disable_system_prompt=False, model=None, temperature=None):
+        return "invoke"
+
+    def invoke_with_tools(self, messages=None, disable_system_prompt=False):
+        return "invoke-tools", []
+
+    def list_models(self, ignore_errors=False):
+        return []
+
+
+def create_session():
+    s = DummySession()
+    s.session_id = 5
+    s.session_alias = "alias"
+    s.session_title = "title"
+    s.last_prompt = "p"
+    s.last_response = "r"
+    s.history.add_message("user", "hi")
+    return s
+
+
+def test_save_and_load(tmp_path):
+    s1 = create_session()
+    file_path = tmp_path / "state.json"
+    serializer.save(s1, file_path)
+    assert json.loads(file_path.read_text())["id"] == 5
+    s2 = DummySession()
+    serializer.load(s2, file_path)
+    assert s2.session_title == "title" and s2.history.get_messages()[0]["content"] == "hi"
+
+
+def test_update_session_from_dict_errors():
+    s = DummySession()
+    for bad in [{}, {"version": "0.1"}, {"version": "1.0"}]:
+        with pytest.raises(RuntimeError):
+            try:
+                serializer.update_session_from_dict(s, bad)
+            except Exception as exc:
+                raise RuntimeError from exc

--- a/tests/unit/test_sessions_init.py
+++ b/tests/unit/test_sessions_init.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+import lair.sessions as sessions
+
+
+def test_get_chat_session_openai(monkeypatch):
+    class DummyOpenAI:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyOpenAI))
+    import lair.sessions.openai_chat_session as ocs
+
+    importlib.reload(ocs)
+    importlib.reload(sessions)
+    session = sessions.get_chat_session("openai_chat")
+    assert isinstance(session, ocs.OpenAIChatSession)
+
+
+def test_get_chat_session_unknown():
+    with pytest.raises(ValueError):
+        sessions.get_chat_session("other")


### PR DESCRIPTION
## Summary
- add unit tests covering BaseChatSession helpers
- add tests for OpenAIChatSession tool handling
- test session serializer save/load logic
- test get_chat_session dispatch

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests/unit/test_base_chat_session.py tests/unit/test_openai_chat_session.py tests/unit/test_session_serializer.py tests/unit/test_sessions_init.py`
- `ruff format lair tests/unit/test_base_chat_session.py tests/unit/test_openai_chat_session.py tests/unit/test_session_serializer.py tests/unit/test_sessions_init.py`
- `mypy lair`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b169987b88320aecd622ef1f53ede