### PR TITLE
Improve module tests

### DIFF
--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
-import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
+import zoneinfo
 
 import lair
 import lair.reporting


### PR DESCRIPTION
## Summary
- add coverage for chat module info
- expand util module tests for run
- exercise Comfy chat parser and helper methods
- test additional reporting behaviors
- sort imports via ruff

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b23b70f7c8320bb0cd673633abb02