### PR TITLE
Improve session-related test coverage

### DIFF
--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
-import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
+import zoneinfo
 
 import lair
 import lair.reporting


### PR DESCRIPTION
## Summary
- add edge case coverage for BaseChatSession
- expand OpenAIChatSession tests
- extend SessionManager tests for alias management and error handling
- run ruff fixes on openai_chat_session

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair tests`
- `mypy lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b23cd49a08320a5af1faa630a9d81