### PR TITLE
Improve ComfyCaller coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - cleanup: refactor workflow and tool call helpers for readability
 - tests: Add FileTool unit tests
 - tests: Add ComfyCaller SSL and URL handling coverage
+- tests: Improve ComfyCaller defaults and workflow coverage
 - tests: Add PythonTool unit tests
 - tests: Increase tmux tool coverage
 - internal: Fix import order to satisfy new ruff checks


### PR DESCRIPTION
## Summary
- test additional ComfyCaller workflows and defaults
- cover early return in ComfyCaller import
- document new coverage improvements in CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b910fc1dc8320a1eece5768b60da1