### PR TITLE
Increase tmux_tool tests

### DIFF
--- a/tests/unit/test_tmux_tool.py
+++ b/tests/unit/test_tmux_tool.py
@@ -1,5 +1,7 @@
 import os
+
 import lair
+import libtmux
 import pytest
 from lair.components.tools.tmux_tool import TmuxTool
 
@@ -276,3 +278,102 @@ def test_ensure_connection_and_failure(tmp_path, monkeypatch):
 def test_read_new_output_no_windows(tool):
     with pytest.raises(Exception):
         tool.read_new_output()
+
+
+def test_get_log_file_name_creates_dirs(tool, tmp_path, monkeypatch):
+    cfg_value = os.path.join(str(tmp_path), "logs/cap-{window_id}.log")
+    lair.config.set("tools.tmux.capture_file_name", cfg_value, no_event=True)
+    window = DummyWindow(5)
+    path = tool.get_log_file_name_and_create_directories(window)
+    assert os.path.isdir(os.path.dirname(path))
+    assert path.endswith("cap-@5.log")
+
+
+def test_definition_generators(tool):
+    assert tool._generate_run_definition()["function"]["name"] == "run"
+    assert tool._generate_send_keys_definition()["function"]["name"] == "send_keys"
+    assert tool._generate_capture_output_definition()["function"]["name"] == "capture_output"
+    assert tool._generate_read_new_output_definition()["function"]["name"] == "read_new_output"
+    assert tool._generate_kill_definition()["function"]["name"] == "kill"
+    assert tool._generate_list_windows_definition()["function"]["name"] == "list_windows"
+    assert tool._generate_attach_window_definition()["function"]["name"] == "attach_window"
+
+
+def test_clean_new_data_options(tool, monkeypatch):
+    lair.config.set("tools.tmux.read_new_output.strip_escape_codes", True, no_event=True)
+    sample = b"line1\nline2\nremain\n"
+    assert tool._clean_new_data(sample, 0, None) == "remain"
+
+    called = {}
+
+    def fake_strip(text):
+        called["hit"] = True
+        return text.replace("ESC", "")
+
+    monkeypatch.setattr(lair.util, "strip_escape_codes", fake_strip)
+    second = tool._clean_new_data(b"cmd\nres1\n", 1, "cmd")
+    assert second == "res1\n"
+    third = tool._clean_new_data(b"ESC\r", 1, None)
+    assert called["hit"] and third == ""
+
+
+def test_run_send_keys_and_window_errors(tool, monkeypatch):
+    tool.session.new_window = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("oops"))
+    err = tool.run()
+    assert err["error"] == "oops"
+
+    tool.session = DummySession()
+    tool.active_window = tool.session.new_window("one")
+    monkeypatch.setattr(tool, "_get_window_by_id", lambda wid: (_ for _ in ()).throw(RuntimeError("bad")))
+    res = tool.send_keys("k", window_id=1)
+    assert res["error"] == "bad"
+
+    monkeypatch.setattr(tool, "_get_window_by_id", lambda wid: (_ for _ in ()).throw(RuntimeError("boom")))
+    out = tool.kill(window_id="@1")
+    assert out["error"] == "boom"
+
+    monkeypatch.setattr(tool, "_ensure_connection", lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+    lst = tool.list_windows()
+    assert lst["error"] == "fail"
+    monkeypatch.setattr(tool, "_ensure_connection", lambda: None)
+    monkeypatch.setattr(tool, "_get_window_by_id", lambda wid: (_ for _ in ()).throw(RuntimeError("attach")))
+    att = tool.attach_window(window_id="@1")
+    assert att["error"] == "attach"
+
+
+class SimpleServer:
+    def __init__(self):
+        self.sessions = []
+        self.new_session_called = False
+
+    def new_session(self, session_name, attach=False):
+        self.new_session_called = True
+        sess = DummySession()
+        sess.name = session_name
+        self.sessions.append(sess)
+        return sess
+
+
+def test_connect_to_tmux_creates_and_reuses(tmp_path, monkeypatch):
+    old = setup_config(tmp_path)
+    server = SimpleServer()
+    monkeypatch.setattr(libtmux, "Server", lambda: server)
+    tool = TmuxTool()
+    tool._connect_to_tmux()
+    assert tool.server is server
+    assert tool.session in server.sessions
+    assert server.new_session_called
+    assert tool.log_files == {}
+    assert tool.log_offsets == {}
+
+    # existing session reused
+    server2 = SimpleServer()
+    exist = DummySession()
+    exist.name = lair.config.get("tools.tmux.session_name")
+    server2.sessions.append(exist)
+    monkeypatch.setattr(libtmux, "Server", lambda: server2)
+    tool2 = TmuxTool()
+    tool2._connect_to_tmux()
+    assert tool2.session is exist
+    assert not server2.new_session_called
+    restore_config(old)


### PR DESCRIPTION
## Summary
- add unit tests for tmux_tool covering error paths and helpers
- include server connection logic and output cleaning tests

## Testing
- `python -m compileall -q lair && ruff check lair && ruff format --check lair && mypy lair && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b913cfac88320b8dbf3d5d0828d79