### PR TITLE
Increase coverage for Comfy module

### DIFF
--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
+import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
-import zoneinfo
 
 import lair
 import lair.reporting


### PR DESCRIPTION
## Summary
- add additional Comfy module unit tests
- fix import order via ruff

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b914aaaa483208187e7de84f4770d