### PR TITLE
Improve chat interface tests

### DIFF
--- a/tests/unit/test_chat_interface_controls.py
+++ b/tests/unit/test_chat_interface_controls.py
@@ -22,10 +22,13 @@ def test_enter_key_on_selected_completion(monkeypatch):
         def __init__(self):
             self.text = ""
             self.cancelled = False
+
         def insert_text(self, txt):
             self.text += txt
+
         def cancel_completion(self):
             self.cancelled = True
+
     buffer = Buffer()
     event = types.SimpleNamespace(app=types.SimpleNamespace(current_buffer=buffer))
     ci._enter_key_on_selected_completion(event)
@@ -71,8 +74,10 @@ def test_toggle_actions(monkeypatch):
 
 def test_switch_to_session_unknown(monkeypatch):
     ci = setup_interface(monkeypatch)
+
     def raise_unknown(id_or_alias, chat_session):
         raise lair.sessions.UnknownSessionException("bad")
+
     monkeypatch.setattr(ci.session_manager, "switch_to_session", raise_unknown)
     captured = []
     monkeypatch.setattr(lair.logging.logger, "error", lambda msg: captured.append(msg))
@@ -83,9 +88,11 @@ def test_switch_to_session_unknown(monkeypatch):
 def test_start_interrupt_and_exit(monkeypatch):
     ci = setup_interface(monkeypatch)
     seq = [KeyboardInterrupt, EOFError]
+
     def fake_prompt():
         exc = seq.pop(0)
         raise exc()
+
     monkeypatch.setattr(ci, "_prompt", fake_prompt)
     with pytest.raises(SystemExit):
         ci.start()
@@ -100,3 +107,71 @@ def test_generate_toolbar_standard(monkeypatch):
     monkeypatch.setattr(shutil, "get_terminal_size", lambda: os.terminal_size((5, 20)))
     bar = ci._generate_toolbar()
     assert "<bottom-toolbar.text>" in bar.value
+
+
+def test_toggle_actions_reverse(monkeypatch):
+    ci = setup_interface(monkeypatch)
+    messages = []
+    monkeypatch.setattr(ci, "_prompt_handler_system_message", lambda m: messages.append(m))
+
+    lair.config.set("chat.enable_toolbar", False)
+    ci.toggle_toolbar(None)
+    assert lair.config.get("chat.enable_toolbar") is True
+    assert messages.pop() == "Bottom toolbar enabled"
+
+    lair.config.set("chat.multiline_input", True)
+    ci.toggle_multiline_input(None)
+    assert lair.config.get("chat.multiline_input") is False
+
+    lair.config.set("style.render_markdown", False)
+    ci.toggle_markdown(None)
+    assert lair.config.get("style.render_markdown") is True
+
+    lair.config.set("tools.enabled", False)
+    ci.toggle_tools(None)
+    assert lair.config.get("tools.enabled") is True
+
+    lair.config.set("chat.verbose", True)
+    ci.toggle_verbose(None)
+    assert lair.config.get("chat.verbose") is False
+
+    lair.config.set("style.word_wrap", True)
+    ci.toggle_word_wrap(None)
+    assert lair.config.get("style.word_wrap") is False
+
+
+def test_event_wrappers(monkeypatch):
+    ci = setup_interface(monkeypatch)
+    calls = []
+    monkeypatch.setattr(ci, "_handle_session_set_alias", lambda: calls.append("alias"))
+    monkeypatch.setattr(ci, "_handle_session_set_title", lambda: calls.append("title"))
+    monkeypatch.setattr(ci, "print_sessions_report", lambda: calls.append("status"))
+    monkeypatch.setattr(ci, "_handle_session_switch", lambda: calls.append("switch"))
+    monkeypatch.setattr(ci, "print_help", lambda: calls.append("help"))
+    monkeypatch.setattr(ci, "print_history", lambda **k: calls.append("history"))
+    monkeypatch.setattr(ci, "print_models_report", lambda **k: calls.append("models"))
+    monkeypatch.setattr(ci, "print_tools_report", lambda: calls.append("tools"))
+    monkeypatch.setattr(lair.sessions.SessionManager, "get_next_session_id", lambda *a: 1)
+    event = object()
+    ci.session_set_alias(event)
+    ci.session_set_title(event)
+    ci.session_status(event)
+    ci.session_switch(event)
+    ci.show_help(event)
+    ci.show_history(event)
+    ci.show_recent_history(event)
+    ci.list_models(event)
+    ci.list_tools(event)
+    f_event = types.SimpleNamespace(key_sequence=[types.SimpleNamespace(key="f1")])
+    ci._f_key(f_event)
+    assert calls == [
+        "alias",
+        "title",
+        "status",
+        "switch",
+        "help",
+        "history",
+        "history",
+        "models",
+        "tools",
+    ]

--- a/tests/unit/test_chat_interface_startup.py
+++ b/tests/unit/test_chat_interface_startup.py
@@ -8,6 +8,7 @@ from tests.helpers.chat_interface import make_interface
 def setup_interface(monkeypatch):
     ci = make_interface(monkeypatch)
     monkeypatch.setattr(prompt_toolkit.application, "run_in_terminal", lambda f: f())
+    ci.reporting.error = lambda msg: ci.reporting.messages.append(("error", msg))
     return ci
 
 
@@ -82,3 +83,72 @@ def test_prompt_invokes_handle_request(monkeypatch):
     ci._prompt()
     assert called[0] == "hi"
     assert "refresh" in called
+
+
+def test_init_starting_session_alias_conflict(monkeypatch, caplog):
+    ci = setup_interface(monkeypatch)
+    monkeypatch.setattr(
+        ci,
+        "_switch_to_session",
+        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u")),
+    )
+    monkeypatch.setattr(ci.session_manager, "is_alias_available", lambda alias: False)
+    monkeypatch.setattr(lair.util, "safe_int", lambda v: None)
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        ci._init_starting_session("dup", create_session_if_missing=True)
+    assert "Alias is already used" in caplog.text
+
+
+def test_init_starting_session_unknown_exit(monkeypatch, caplog):
+    ci = setup_interface(monkeypatch)
+    monkeypatch.setattr(
+        ci,
+        "_switch_to_session",
+        lambda *a, **k: (_ for _ in ()).throw(lair.sessions.UnknownSessionException("u")),
+    )
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        ci._init_starting_session("missing", create_session_if_missing=False)
+    assert "Unknown session: missing" in caplog.text
+
+
+def test_get_embedded_response_empty_section(monkeypatch):
+    ci = setup_interface(monkeypatch)
+    msg = "<answer>()</answer>"
+    assert ci._get_embedded_response(msg, 0) is None
+
+
+def test_handle_request_command_error(monkeypatch):
+    ci = setup_interface(monkeypatch)
+
+    def bad(c, a, s):
+        raise ValueError("boom")
+
+    ci.commands = {"/bad": {"callback": bad}}
+    captured = []
+    monkeypatch.setattr(ci.reporting, "error", lambda m: captured.append(m))
+    assert ci._handle_request_command("/bad arg") is False
+    assert any("Command failed" in m for m in captured)
+
+
+def test_handle_request_empty_and_error(monkeypatch):
+    ci = setup_interface(monkeypatch)
+    assert ci._handle_request("") is False
+    monkeypatch.setattr(ci, "_handle_request_chat", lambda r: (_ for _ in ()).throw(RuntimeError("fail")))
+    captured = []
+    monkeypatch.setattr(ci.reporting, "error", lambda m: captured.append(m))
+    assert ci._handle_request("hi") is False
+    assert any("Chat failed" in m for m in captured)
+
+
+def test_handle_request_chat_attachment_only(monkeypatch):
+    ci = setup_interface(monkeypatch)
+    lair.config.set("chat.attachments_enabled", True)
+    lair.config.set("chat.attachment_syntax_regex", r"<<(.*?)>>")
+    monkeypatch.setattr(
+        lair.util,
+        "get_attachments_content",
+        lambda files: ([{"type": "text", "text": "file"}], [{"role": "user", "content": "c"}]),
+    )
+    before = ci.chat_session.history.num_messages()
+    assert ci._handle_request_chat("<<f.txt>>") is True
+    assert ci.chat_session.history.num_messages() > before


### PR DESCRIPTION
## Summary
- expand startup test suite with more error cases
- ensure toggles cover both branches
- exercise chat interface event wrappers

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests/unit/test_chat_interface_startup.py tests/unit/test_chat_interface_controls.py`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b911fcd648320929dcb28f5062680