### PR TITLE
Fix ruff issues in tests

### DIFF
--- a/tests/unit/test_core_file_utils.py
+++ b/tests/unit/test_core_file_utils.py
@@ -1,9 +1,11 @@
-import mimetypes
-import os
 import base64
 import datetime
+import mimetypes
+import os
 import subprocess
+
 import pytest
+
 import lair
 import lair.util.core as core
 
@@ -38,7 +40,7 @@ def test_misc_utils(monkeypatch):
 
 
 def test_expand_filename_list_errors(tmp_path):
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="File not found"):
         core.expand_filename_list([str(tmp_path / "nofile")])
 
     f = tmp_path / "a.txt"
@@ -88,8 +90,12 @@ def test_read_pdf_limits(tmp_path, monkeypatch):
     )
     out = core.read_pdf(dummy_file, enforce_limits=True)
     assert len(out) == 5
-    monkeypatch.setattr(lair.config, "active", {**lair.config.active, "misc.text_attachment_truncate": False})
-    with pytest.raises(Exception):
+    monkeypatch.setattr(
+        lair.config,
+        "active",
+        {**lair.config.active, "misc.text_attachment_truncate": False},
+    )
+    with pytest.raises(Exception, match="Attachment size exceeds limit"):
         core.read_pdf(dummy_file, enforce_limits=True)
 
 
@@ -109,7 +115,7 @@ def test_pdf_and_text_files(tmp_path, monkeypatch):
     assert msg2["content"].endswith("abc")
 
     textfile.write_bytes(b"\xff\xfe")
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="File attachment is not text"):
         core._get_attachments_content__text_file(str(textfile))
 
 
@@ -148,7 +154,7 @@ def test_text_file_limits(tmp_path, monkeypatch):
         "active",
         {**lair.config.active, "misc.text_attachment_max_size": 3, "misc.text_attachment_truncate": False},
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Attachment size exceeds limit"):
         core._get_attachments_content__text_file(str(f))
 
     monkeypatch.setattr(

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,5 +1,6 @@
-import lair.events as events
 import pytest
+
+import lair.events as events
 
 
 def test_subscribe_and_fire():

--- a/tests/unit/test_file_tool.py
+++ b/tests/unit/test_file_tool.py
@@ -1,6 +1,8 @@
 import os
-import lair
+
 import pytest
+
+import lair
 from lair.components.tools.file_tool import FileTool
 
 
@@ -78,7 +80,7 @@ def test_directory_creation_and_removal(file_tool):
 
 def test_generate_definitions(file_tool):
     defs = file_tool._generate_list_directory_definition()
-    assert "list_directory" == defs["function"]["name"]
+    assert defs["function"]["name"] == "list_directory"
     write_def = file_tool._generate_write_file_definition()
     assert lair.config.get("tools.file.path") in write_def["function"]["description"]
 
@@ -120,7 +122,8 @@ def test_read_file_skips_directories(file_tool):
     base = lair.config.get("tools.file.path")
     dir1 = os.path.join(base, "dir")
     os.makedirs(dir1)
-    open(os.path.join(dir1, "f.txt"), "w").write("data")
+    with open(os.path.join(dir1, "f.txt"), "w") as fh:
+        fh.write("data")
     os.makedirs(os.path.join(base, "dir2"))
     res = file_tool.read_file("**")
     assert list(res["file_content"].values()) == ["data"]

--- a/tests/unit/test_history_schema.py
+++ b/tests/unit/test_history_schema.py
@@ -1,5 +1,5 @@
-import pytest
 import jsonschema
+import pytest
 
 from lair.components.history import schema
 

--- a/tests/unit/test_logging_and_loader.py
+++ b/tests/unit/test_logging_and_loader.py
@@ -1,4 +1,5 @@
 import types
+
 import pytest
 
 import lair.logging as logging_mod
@@ -30,7 +31,7 @@ def test_module_loader_register(tmp_path):
     loader._register_module(mod, tmp_path)
     name = loader._get_module_name(mod, tmp_path)
     assert name in loader.modules
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="repeat name"):
         loader._register_module(mod, tmp_path)
 
 
@@ -39,7 +40,7 @@ def test_module_loader_validate(tmp_path):
     mod = make_dummy_module(tmp_path)
     loader._validate_module(mod)
     bad = types.ModuleType("bad")
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="_module_info not defined"):
         loader._validate_module(bad)
 
 def test_get_module_files(tmp_path):


### PR DESCRIPTION
## Summary
- sort imports across several test modules
- add context manager and reorder assertion in FileTool tests
- tighten `pytest.raises` checks in utility tests

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c273186a88320932736824abda82c