### PR TITLE
Fix import order warnings

### DIFF
--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
+import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
-import zoneinfo
 
 import lair
 import lair.reporting

--- a/tests/unit/test_openai_chat_session.py
+++ b/tests/unit/test_openai_chat_session.py
@@ -1,8 +1,9 @@
 import importlib
-import pytest
 import json
 import sys
 import types
+
+import pytest
 
 import lair
 

--- a/tests/unit/test_python_tool.py
+++ b/tests/unit/test_python_tool.py
@@ -1,5 +1,6 @@
 import subprocess
 import types
+
 import lair
 from lair.components.tools.python_tool import PythonTool
 

--- a/tests/unit/test_reporting_behavior.py
+++ b/tests/unit/test_reporting_behavior.py
@@ -1,8 +1,10 @@
+import traceback
+
 import pytest
 import rich
 import rich.markdown
 import rich.text
-import traceback
+
 import lair
 from lair.reporting.reporting import Reporting, ReportingSingletoneMeta
 
@@ -89,6 +91,7 @@ def test_llm_output_thoughts(monkeypatch):
     rep = make_reporting(monkeypatch)
     calls = []
     monkeypatch.setattr(rep, "print_rich", lambda *a, **k: calls.append(a[0]))
+
     def cfg(key):
         return {
             "style.thoughts.hide_thoughts": True,
@@ -96,10 +99,12 @@ def test_llm_output_thoughts(monkeypatch):
             "style.llm_output_thought": "th",
             "style.llm_output": "out",
         }.get(key, False)
+
     monkeypatch.setattr(lair.config, "get", cfg)
     rep._llm_output__with_thoughts("begin <thought>secret</thought> end")
     assert len(calls) == 2  # thought hidden
     calls.clear()
+
     def cfg2(key):
         return {
             "style.thoughts.hide_thoughts": False,
@@ -107,10 +112,12 @@ def test_llm_output_thoughts(monkeypatch):
             "style.llm_output_thought": "th",
             "style.llm_output": "out",
         }.get(key, False)
+
     monkeypatch.setattr(lair.config, "get", cfg2)
     rep._llm_output__with_thoughts("begin <thought>secret</thought> end")
     assert any(getattr(c, "markup", "") == "secret" for c in calls)
     calls.clear()
+
     def cfg3(key):
         return {
             "style.thoughts.hide_thoughts": False,
@@ -118,6 +125,7 @@ def test_llm_output_thoughts(monkeypatch):
             "style.llm_output_thought": "th",
             "style.llm_output": "out",
         }.get(key, False)
+
     monkeypatch.setattr(lair.config, "get", cfg3)
     rep._llm_output__with_thoughts("begin <thought>secret</thought> end")
     assert any("<thought>" in getattr(c, "markup", "") for c in calls)
@@ -128,6 +136,7 @@ def test_llm_output(monkeypatch):
     msgs = []
     monkeypatch.setattr(rep, "_llm_output__with_thoughts", lambda m: msgs.append("t"))
     monkeypatch.setattr(rep, "print_rich", lambda *a, **k: msgs.append(a[0]))
+
     def cfg(key):
         return {
             "style.render_markdown": False,
@@ -135,16 +144,19 @@ def test_llm_output(monkeypatch):
             "style.thoughts.enabled": False,
             "style.llm_output_heading": "h",
         }.get(key, False)
+
     monkeypatch.setattr(lair.config, "get", cfg)
     rep.llm_output("hi", show_heading=True)
     assert any(isinstance(m, rich.text.Text) for m in msgs)
     msgs.clear()
+
     def cfg2(key):
         return {
             "style.render_markdown": True,
             "style.thoughts.enabled": True,
             "style.llm_output_heading": "h",
         }.get(key, False)
+
     monkeypatch.setattr(lair.config, "get", cfg2)
     rep.llm_output("hi")
     assert "t" in msgs

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,5 +1,6 @@
 import argparse
 import types
+
 import pytest
 
 import lair

--- a/tests/unit/test_search_tool.py
+++ b/tests/unit/test_search_tool.py
@@ -1,5 +1,4 @@
 import lair
-
 from lair.components.tools.search_tool import SearchTool
 
 

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -1,7 +1,9 @@
 import importlib
-import sys
-import pytest
 import json
+import sys
+
+import pytest
+
 import lair
 from lair.components.history.chat_history import ChatHistory
 
@@ -32,8 +34,7 @@ class DummyCursor:
         return bool(self.items)
 
     def __iter__(self):
-        for item in self.items:
-            yield item
+        yield from self.items
 
 
 class DummyTxn:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,8 +1,8 @@
+import sys
 import types
 
 import lair
 from lair.sessions.base_chat_session import BaseChatSession
-import sys
 
 
 class DummySession(BaseChatSession):
@@ -44,6 +44,7 @@ def test_openai_list_models(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyOpenAI))
     import importlib
+
     import lair.sessions.openai_chat_session as ocs
 
     importlib.reload(ocs)

--- a/tests/unit/test_tmux_tool.py
+++ b/tests/unit/test_tmux_tool.py
@@ -1,8 +1,9 @@
 import os
 
-import lair
 import libtmux
 import pytest
+
+import lair
 from lair.components.tools.tmux_tool import TmuxTool
 
 


### PR DESCRIPTION
## Summary
- order imports properly in tests
- use `yield from` in `test_session_manager` dummy cursor
- clean up imports in OpenAI session

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c273d8d2883209b54440e8f2f1924