### PR TITLE
Fix import order for new ruff rules

### DIFF
--- a/tests/unit/test_tool_set.py
+++ b/tests/unit/test_tool_set.py
@@ -1,4 +1,5 @@
 import pytest
+
 import lair
 from lair.components.tools.tool_set import ToolSet
 


### PR DESCRIPTION
## Summary
- fix import order in `tests/unit/test_tool_set.py`

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c276002508320929e9ba4fa516518