### PR TITLE
Fix ruff issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - docker: Add lair into youtube image
 - tests: Increase ChatHistory coverage
 - tests: Fix Python tool cleanup path assertions
+- tests: adjust ruff strictness and replace broad exception checks
 - tests: Increase ToolSet coverage
 - deps: Replace pyflakes with ruff for linting
 - documentation: Expand README outpainting example

--- a/lair/components/tools/tmux_tool.py
+++ b/lair/components/tools/tmux_tool.py
@@ -101,7 +101,7 @@ class TmuxTool:
             if window.get("window_id") == window_id:
                 return window
 
-        raise Exception(f"Requested window id not found: {window_id}")
+        raise ValueError(f"Requested window id not found: {window_id}")
 
     def _ensure_connection(self):
         try:
@@ -113,7 +113,7 @@ class TmuxTool:
             try:
                 self._connect_to_tmux()
             except Exception as connect_error:
-                raise Exception(f"Tmux server unavailable: {connect_error}") from connect_error
+                raise RuntimeError(f"Tmux server unavailable: {connect_error}") from connect_error
 
     def _get_output(self, return_mode, *, prune_line=None, window_id=None):
         """
@@ -124,7 +124,7 @@ class TmuxTool:
         elif return_mode == "screen":
             return self.capture_output(window_id=window_id)
         else:
-            raise Exception("Invalid return_mode. Accepted values are stream or screen (screen capture)")
+            raise ValueError("Invalid return_mode. Accepted values are stream or screen (screen capture)")
 
     def _generate_run_definition(self):
         return {
@@ -301,7 +301,7 @@ class TmuxTool:
     def capture_output(self, *, window_id=None):
         self._ensure_connection()
         if not self.session.windows:
-            raise Exception("No active tmux windows available.")
+            raise RuntimeError("No active tmux windows available.")
 
         window = self.active_window if window_id is None else self._get_window_by_id(window_id)
         pane = window.attached_pane or window.active_pane
@@ -344,7 +344,7 @@ class TmuxTool:
         """
         self._ensure_connection()
         if not self.session.windows:
-            raise Exception("No active tmux windows available.")
+            raise RuntimeError("No active tmux windows available.")
 
         max_size = min(
             max_size or lair.config.get("tools.tmux.read_new_output.max_size_default"),
@@ -367,7 +367,7 @@ class TmuxTool:
         pane = window.attached_pane or window.active_pane
         pane_id = pane.get("pane_id")
         if pane_id not in self.log_files:
-            raise Exception("Connection to pane lost.")
+            raise RuntimeError("Connection to pane lost.")
         log_file = self.log_files[pane_id]
         offset = self.log_offsets.get(pane_id, 0)
         return pane_id, log_file, offset

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
-import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
+import zoneinfo
 
 import lair
 import lair.reporting

--- a/tests/unit/test_tmux_tool.py
+++ b/tests/unit/test_tmux_tool.py
@@ -110,7 +110,7 @@ def test_get_window_by_id_and_errors(tool):
     assert tool._get_window_by_id(w1.get("window_id")) is w1
     assert tool._get_window_by_id(w1.get("window_id").lstrip("@")) is w1
     assert tool._get_window_by_id(None) is None
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         tool._get_window_by_id("@99")
 
 
@@ -131,7 +131,7 @@ def test_get_output_modes(tool, monkeypatch):
     assert called["mode"] == "stream"
     assert tool._get_output("screen") == {"out": "screen"}
     assert called["mode"] == "screen"
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         tool._get_output("bad")
 
 
@@ -179,7 +179,7 @@ def test_send_keys_valid_and_errors(tool, monkeypatch):
 
 
 def test_capture_output_and_errors(tool):
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         tool.capture_output()
     tool.session.new_window("one")
     tool.active_window = tool.session.windows[0]
@@ -215,7 +215,7 @@ def test_read_new_output_flow(tool, tmp_path):
 
     # connection lost
     del tool.log_files[pane.get("pane_id")]
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         tool.read_new_output()
 
 
@@ -271,13 +271,13 @@ def test_ensure_connection_and_failure(tmp_path, monkeypatch):
 
     new_tool.server = DummyServer(fail=True)
     monkeypatch.setattr(new_tool, "_connect_to_tmux", connect_fail)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         new_tool._ensure_connection()
     restore_config(old)
 
 
 def test_read_new_output_no_windows(tool):
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         tool.read_new_output()
 
 


### PR DESCRIPTION
## Summary
- fix import order for OpenAI chat session
- raise specific errors in TmuxTool
- update tests for stricter checks
- document ruff strictness update

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c545333dc83208605ed516a1ae9eb