### PR TITLE
Remove fallback YAML parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 - comfy: Fix `ltxv-i2v` default model version
 - util: Fix issue where image attachments stopped working
-- config: Provide simple YAML parser when PyYAML is unavailable
+- core: Rely exclusively on PyYAML for configuration parsing
 - cli: Reduce complexity of keybindings setup
 - tests: Increase coverage for chat interface reports
 - comfyscript: Restart watch thread correctly

--- a/lair/sessions/openai_chat_session.py
+++ b/lair/sessions/openai_chat_session.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
+import zoneinfo
 from typing import Any, Optional, cast
 
 import openai
-import zoneinfo
 
 import lair
 import lair.reporting

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -11,18 +11,13 @@ import re
 import shlex
 import subprocess
 import tempfile
-from typing import Any, Optional
+from typing import Optional
 
 import pdfplumber
+import yaml
 
 import lair
 from lair.logging import logger
-
-yaml: Any | None
-try:
-    import yaml  # type: ignore
-except Exception:
-    yaml = None
 
 subprocess_run = subprocess.run
 
@@ -53,80 +48,11 @@ def save_file(filename, contents):
         fd.write(contents)
 
 
-_BLOCK_MARKERS = {"|", "|-", ">", ">-"}
+def parse_yaml_text(text: str) -> dict:
+    """Parse YAML content using PyYAML."""
 
-
-def _convert_scalar(value: str) -> object:
-    if value.startswith("'") and value.endswith("'"):
-        return value[1:-1]
-    if value.startswith('"') and value.endswith('"'):
-        return bytes(value[1:-1], "utf-8").decode("unicode_escape")
-    if value.lower() in {"true", "false"}:
-        return value.lower() == "true"
-    if value in {"", "null", "~"}:
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            return value
-
-
-def _simple_yaml_parse(text: str) -> dict:
-    result: dict[str, object] = {}
-    stack = [result]
-    indents = [0]
-    lines = text.splitlines()
-    i = 0
-    while i < len(lines):
-        raw = lines[i]
-        if not raw.strip() or raw.lstrip().startswith("#"):
-            i += 1
-            continue
-
-        indent = len(raw) - len(raw.lstrip())
-        while indent < indents[-1]:
-            stack.pop()
-            indents.pop()
-
-        line = raw.strip()
-        key, value = line.split(":", 1)
-        key = key.strip()
-        value = value.strip()
-        i += 1
-
-        if value in _BLOCK_MARKERS:
-            block_indent = indent + 2
-            block: list[str] = []
-            while i < len(lines) and len(lines[i]) - len(lines[i].lstrip()) >= block_indent:
-                block.append(lines[i][block_indent:])
-                i += 1
-            stack[-1][key] = (" ".join(block) if value.startswith(">") else "\n".join(block)).rstrip()
-            continue
-
-        if not value:
-            new_dict: dict[str, object] = {}
-            stack[-1][key] = new_dict
-            stack.append(new_dict)
-            indents.append(indent + 2)
-            continue
-
-        stack[-1][key] = _convert_scalar(value)
-
-    return result
-
-
-def parse_yaml_text(text):
-    if yaml is not None:
-        try:
-            data = yaml.safe_load(text)
-            if data:
-                return data
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("YAML parsing failed: %s", exc)
-    return _simple_yaml_parse(text)
+    data = yaml.safe_load(text)
+    return data or {}
 
 
 def parse_yaml_file(filename):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2281,6 +2281,69 @@ files = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 description = "JSON Referencing + Python"
@@ -2981,4 +3044,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e295702ed8e3b3d536648b42fbed587d22c38f83ebb0e0c10da6b505985fc76f"
+content-hash = "8deb754dc9b49d3e5a370e6b2e855e9f6726a9dcdb25a0bd5c8737df6fc3c096"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ jinja2 = "^3.1.5"
 lmdb = "^1.6.2"
 libtmux = "^0.46.0"
 ddgs = "^9.3.1"
+pyyaml = "^6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ modules_to_stub = [
     "trafilatura",
     "PIL",
     "duckduckgo_search",
-    "yaml",
     "requests",
     "libtmux",
     "lmdb",
@@ -25,8 +24,6 @@ for name in modules_to_stub:
         # pdfplumber is only used in tests and may not be installed. Provide a
         # minimal stub so monkeypatching works without raising AttributeError.
         module.open = lambda *args, **kwargs: None
-    elif name == "yaml":
-        module.safe_load = lambda *a, **k: {}
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,8 +1,3 @@
-import builtins
-import importlib
-import sys
-import types
-
 import lair.util.core as core
 
 
@@ -31,35 +26,3 @@ def test_expand_filename_list(tmp_path):
     pattern = str(tmp_path / "*.txt")
     result = core.expand_filename_list([pattern])
     assert str(f1) in result and str(f2) in result
-
-
-def test_convert_scalar_none():
-    assert core._convert_scalar("null") is None
-    assert core._convert_scalar("~") is None
-    assert core._convert_scalar("") is None
-
-
-def test_parse_yaml_text_no_yaml(monkeypatch):
-    # simulate missing yaml module at import time
-    monkeypatch.setitem(sys.modules, "yaml", None)
-    orig_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "yaml":
-            raise ImportError
-        return orig_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    importlib.reload(core)
-    assert core.yaml is None
-    assert core.parse_yaml_text("a: 1") == {"a": 1}
-    monkeypatch.setattr(builtins, "__import__", orig_import)
-    importlib.reload(core)
-
-
-def test_parse_yaml_text_fallback(monkeypatch):
-    def fail(_text):
-        raise Exception("boom")
-
-    monkeypatch.setattr(core, "yaml", types.SimpleNamespace(safe_load=fail))
-    assert core.parse_yaml_text("b: 2") == {"b": 2}

--- a/tests/unit/test_search_tool.py
+++ b/tests/unit/test_search_tool.py
@@ -51,7 +51,7 @@ def make_tool(monkeypatch):
             self.params.append(("news", query, max_results))
             return []
 
-    monkeypatch.setattr(lair.components.tools.search_tool.duckduckgo_search, "DDGS", DummyDDGS)
+    monkeypatch.setattr(lair.components.tools.search_tool, "DDGS", DummyDDGS)
     return SearchTool()
 
 


### PR DESCRIPTION
## Summary
- depend on PyYAML at runtime
- simplify util.parse_yaml_text and drop custom parser
- clean up YAML stubs and parser tests
- fix search tool tests to patch DDGS

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c5801c7b08320a72ff8ba8dadcada