### PR TITLE
Add CLI run module docs and typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - documentation: Expand README outpainting example
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
+- cli: Add missing docstrings and annotations to run module
 
 # v0.8.1 - Bug fixes
 


### PR DESCRIPTION
## Summary
- document cli run module
- annotate cli run subcommand helpers

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: Found 1262 errors)*
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c667341e083209f369ab39b57659e