### PR TITLE
Fix docstrings for packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - documentation: Expand README outpainting example
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
+- internal: Add missing package docstrings and type hints
 
 # v0.8.1 - Bug fixes
 

--- a/lair/__init__.py
+++ b/lair/__init__.py
@@ -1,10 +1,22 @@
+"""Lair top-level package.
+
+This package exposes the public API, including the configuration object and a
+helper function for retrieving the installed version of the package.
+"""
+
 import importlib.metadata
 
 from lair import events
 from lair.config import Configuration
 
 
-def version():
+def version() -> str:
+    """Return the installed version of ``lair``.
+
+    Returns:
+        str: The version string as defined in package metadata.
+
+    """
     return importlib.metadata.version("lair")
 
 

--- a/lair/cli/__init__.py
+++ b/lair/cli/__init__.py
@@ -1,3 +1,5 @@
+"""Command-line interface components for Lair."""
+
 from lair.cli.chat_interface import ChatInterface
 
 __all__ = ["ChatInterface"]


### PR DESCRIPTION
## Summary
- add a module description and version docstring to `lair`
- document the CLI package
- note docstring and annotation cleanups in the changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: 1258 errors)*
- `ruff format lair`
- `mypy lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c65f76bd08320a22e729cc89dd550