### PR TITLE
Improve docstrings and typing

### DIFF
--- a/lair/components/history/schema.py
+++ b/lair/components/history/schema.py
@@ -1,3 +1,8 @@
+"""Schema definitions and validation helpers for chat history messages."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import jsonschema
 
 MESSAGES_SCHEMA = {
@@ -108,9 +113,16 @@ MESSAGES_SCHEMA = {
 }
 
 
-def validate_messages(messages):
-    """Validate a list of messages
-    Raise an exception if it is invalid
+def validate_messages(messages: Sequence[Mapping[str, Any]]) -> None:
+    """Validate a list of chat messages against ``MESSAGES_SCHEMA``.
+
+    Args:
+        messages: The list of messages to validate.
+
+    Raises:
+        jsonschema.exceptions.ValidationError: If the messages do not conform
+            to the schema.
+
     """
     try:
         jsonschema.validate(instance=messages, schema=MESSAGES_SCHEMA)

--- a/lair/components/tools/__init__.py
+++ b/lair/components/tools/__init__.py
@@ -1,3 +1,7 @@
+"""Utility functions and defaults for the built-in tooling system."""
+
+from typing import Optional
+
 from .file_tool import FileTool
 from .python_tool import PythonTool
 from .search_tool import SearchTool
@@ -12,7 +16,7 @@ DEFAULT_TOOLS = [
 ]
 
 # Lookup for tool classes by their friendly names
-TOOLS = {
+TOOLS: dict[str, type] = {
     FileTool.name: FileTool,
     PythonTool.name: PythonTool,
     SearchTool.name: SearchTool,
@@ -20,13 +24,33 @@ TOOLS = {
 }
 
 
-def get_tool_class_by_name(name):
+def get_tool_class_by_name(name: str) -> Optional[type]:
+    """Return the registered tool class for ``name`` if it exists.
+
+    Args:
+        name: The friendly name of the tool.
+
+    Returns:
+        The tool class or ``None`` if ``name`` is unknown.
+
+    """
     return TOOLS.get(name)
 
 
-def get_tool_classes_from_str(tool_names_str):
-    """Take a comma delimited list of tool names and return a list of classes"""
-    classes = []
+def get_tool_classes_from_str(tool_names_str: str) -> None:
+    """Build a list of classes from a comma-separated string of tool names.
+
+    Args:
+        tool_names_str: Comma-separated friendly tool names.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If any tool name is not registered.
+
+    """
+    classes: list[type] = []
     for name in tool_names_str.split(","):
         name = name.strip()
 


### PR DESCRIPTION
## Summary
- document history schema module and add parameter typing
- clarify docstrings in tool helpers and annotate types

## Testing
- `python -m compileall -q lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c66b3ff3c8320947be74e35131bab