### PR TITLE
Fix FileTool docs and typing

### DIFF
--- a/lair/components/tools/file_tool.py
+++ b/lair/components/tools/file_tool.py
@@ -1,21 +1,38 @@
+"""File system tools for use with :class:`~lair.components.tools.tool_set.ToolSet`."""
+
+from __future__ import annotations
+
 import datetime
 import glob
 import grp
 import os
 import pwd
 import stat
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .tool_set import ToolSet
 
 import lair
 from lair.logging import logger
 
 
 class FileTool:
+    """Tools for manipulating files in the configured workspace."""
+
     name = "file"
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize the tool."""
         pass
 
-    def add_to_tool_set(self, tool_set):
+    def add_to_tool_set(self, tool_set: ToolSet) -> None:
+        """Register file manipulation tools with a :class:`ToolSet`.
+
+        Args:
+            tool_set: The tool set to update with file operations.
+
+        """
         tool_set.add_tool(
             class_name=self.__class__.__name__,
             name="list_directory",
@@ -59,8 +76,19 @@ class FileTool:
             handler=lambda *args, **kwargs: self.remove_directory(*args, **kwargs),
         )
 
-    def _resolve_path(self, path):
-        """Resolve the provided path relative to the path and ensure it's allowed."""
+    def _resolve_path(self, path: str) -> str:
+        """Resolve a path relative to the workspace.
+
+        Args:
+            path: The input path, absolute or relative to the workspace.
+
+        Returns:
+            The absolute path within the workspace.
+
+        Raises:
+            ValueError: If the resolved path lies outside the workspace.
+
+        """
         workspace = os.path.abspath(lair.config.get("tools.file.path"))
         if not os.path.isabs(path):
             path = os.path.join(workspace, path)
@@ -69,7 +97,8 @@ class FileTool:
             raise ValueError(f"Access denied: {absolute_path} is outside the workspace.")
         return absolute_path
 
-    def _generate_list_directory_definition(self):
+    def _generate_list_directory_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``list_directory`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -89,7 +118,16 @@ class FileTool:
             },
         }
 
-    def list_directory(self, directory):
+    def list_directory(self, directory: str) -> dict[str, Any]:
+        """List the contents of a directory within the workspace.
+
+        Args:
+            directory: The directory path relative to the workspace.
+
+        Returns:
+            Mapping with a ``contents`` key on success or an ``error`` key on failure.
+
+        """
         try:
             dir_path = self._resolve_path(directory)
             if not os.path.isdir(dir_path):
@@ -118,7 +156,8 @@ class FileTool:
             logger.warning(f"list_directory(): Error encountered: {error}")
             return {"error": str(error)}
 
-    def _generate_read_file_definition(self):
+    def _generate_read_file_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``read_file`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -144,7 +183,16 @@ class FileTool:
             },
         }
 
-    def read_file(self, path):
+    def read_file(self, path: str) -> dict[str, Any]:
+        """Read files matched by ``path`` and return their contents.
+
+        Args:
+            path: File path or glob pattern relative to the workspace.
+
+        Returns:
+            Mapping with a ``file_content`` key on success or an ``error`` key on failure.
+
+        """
         try:
             workspace = os.path.abspath(lair.config.get("tools.file.path"))
 
@@ -172,7 +220,8 @@ class FileTool:
             logger.warning(f"read_file(): Error encountered: {error}")
             return {"error": str(error)}
 
-    def _generate_write_file_definition(self):
+    def _generate_write_file_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``write_file`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -193,7 +242,17 @@ class FileTool:
             },
         }
 
-    def write_file(self, path, content):
+    def write_file(self, path: str, content: str) -> dict[str, Any]:
+        """Write ``content`` to ``path`` within the workspace.
+
+        Args:
+            path: Destination file path relative to the workspace.
+            content: Text to write to the file.
+
+        Returns:
+            Mapping with a ``message`` key on success or an ``error`` key on failure.
+
+        """
         try:
             file_path = self._resolve_path(path)
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
@@ -204,7 +263,8 @@ class FileTool:
             logger.warning(f"write_file(): Error encountered: {error}")
             return {"error": str(error)}
 
-    def _generate_delete_file_definition(self):
+    def _generate_delete_file_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``delete_file`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -222,7 +282,16 @@ class FileTool:
             },
         }
 
-    def delete_file(self, path):
+    def delete_file(self, path: str) -> dict[str, Any]:
+        """Delete a file from the workspace.
+
+        Args:
+            path: File path relative to the workspace.
+
+        Returns:
+            Mapping with a ``message`` key on success or an ``error`` key on failure.
+
+        """
         try:
             file_path = self._resolve_path(path)
             if not os.path.isfile(file_path):
@@ -233,7 +302,8 @@ class FileTool:
             logger.warning(f"delete_file(): Error encountered: {error}")
             return {"error": str(error)}
 
-    def _generate_make_directory_definition(self):
+    def _generate_make_directory_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``make_directory`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -253,7 +323,16 @@ class FileTool:
             },
         }
 
-    def make_directory(self, path):
+    def make_directory(self, path: str) -> dict[str, Any]:
+        """Create a directory inside the workspace.
+
+        Args:
+            path: Directory path relative to the workspace.
+
+        Returns:
+            Mapping with a ``message`` key on success or an ``error`` key on failure.
+
+        """
         try:
             dir_path = self._resolve_path(path)
             os.makedirs(dir_path, exist_ok=True)
@@ -262,7 +341,8 @@ class FileTool:
             logger.warning(f"make_directory(): Error encountered: {error}")
             return {"error": str(error)}
 
-    def _generate_remove_directory_definition(self):
+    def _generate_remove_directory_definition(self) -> dict[str, Any]:
+        """Return the definition for the ``remove_directory`` tool."""
         workspace = lair.config.get("tools.file.path")
         return {
             "type": "function",
@@ -282,7 +362,16 @@ class FileTool:
             },
         }
 
-    def remove_directory(self, path):
+    def remove_directory(self, path: str) -> dict[str, Any]:
+        """Remove an empty directory from the workspace.
+
+        Args:
+            path: Directory path relative to the workspace.
+
+        Returns:
+            Mapping with a ``message`` key on success or an ``error`` key on failure.
+
+        """
         try:
             dir_path = self._resolve_path(path)
             if not os.path.isdir(dir_path):


### PR DESCRIPTION
## Summary
- add module docs and type hints to FileTool
- provide structured docstrings for FileTool methods
- ensure tools module passes mypy and unit tests

## Testing
- `poetry run python -m compileall -q lair`
- `poetry run ruff check lair/components/tools/file_tool.py`
- `poetry run ruff format lair/components/tools/file_tool.py`
- `poetry run mypy lair`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c66bbb4c083208339a3213a0ce17d