### PR TITLE
Fix ToolSet docstrings and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - tests: Enforce 90% minimum test coverage and add many new tests.
 - docker: Add lair into youtube image
 - documentation: Expand README outpainting example
+- tools: improve docstrings and type hints for ToolSet
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
 

--- a/lair/components/tools/tool_set.py
+++ b/lair/components/tools/tool_set.py
@@ -1,43 +1,74 @@
+"""Utilities for managing tool classes and invoking their handlers."""
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
 import lair.components.tools
 from lair.logging import logger
 
 
 class ToolSet:
-    def __init__(self, *, tools=None):
-        """Create a collection of tools
+    """Container for managing and invoking individual tools."""
 
-        Arguments:
-           tools: A list of tool classes to include. When not provided, the default tools are included
+    def __init__(self, *, tools: list[type] | None = None) -> None:
+        """Initialize the tool set.
+
+        Args:
+            tools: List of tool classes to include. When ``None`` the default
+                tools defined by :mod:`lair.components.tools` are used.
 
         """
-        self.requested_tools = None
-        self.tools = {}  # function name -> {}
+        self.requested_tools: list[type] | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
         self._init_tools(tools)
 
-    def _init_tools(self, tools):
+    def _init_tools(self, tools: list[type] | None) -> None:
+        """Instantiate each tool class and register its tools.
+
+        Args:
+            tools: List of tool classes to instantiate. If ``None`` the default
+                tool list is used.
+
+        """
         self.requested_tools = lair.components.tools.DEFAULT_TOOLS if tools is None else tools
 
-        # Instantiate each tool collection and register the tools in our ToolSet() instance
         for tool in self.requested_tools:
             tool().add_to_tool_set(self)
 
-    def update_tools(self, tools=None):
-        """Recreate all tools in the tool set
+    def update_tools(self, tools: list[type] | None = None) -> None:
+        """Recreate the tool set with the provided tool classes.
 
-        Arguments:
-           tools: A list of tool classes to include. When not provided, the default tools are included
+        Args:
+            tools: List of tool classes to include. When ``None`` the default
+                tools are loaded.
 
         """
         self._init_tools(tools)
 
-    def add_tool(self, *, name, flags, definition=None, definition_handler=None, handler, class_name):
-        """Register a new tool
+    def add_tool(
+        self,
+        *,
+        name: str,
+        flags: list[str],
+        definition: dict[str, Any] | None = None,
+        definition_handler: Callable[[], dict[str, Any]] | None = None,
+        handler: Callable[..., dict[str, Any]],
+        class_name: str,
+    ) -> None:
+        """Register a new tool in the collection.
 
-        Arguments:
-          flags: A list of config keys, each of which must be true for the tool to be enabled
-          definition: The structured definition of the function and its parameter in OpenAI API format
-          definition_handler: A function that returns a definition, allowing for dynamic definitions.
-              When provided, definition_handler takes precedence over definition
+        Args:
+            name: Unique name used to call the tool.
+            flags: Configuration flags required for the tool to be enabled.
+            definition: Structured definition of the function in OpenAI format.
+            definition_handler: Callable returning a definition at runtime.
+                Takes precedence over ``definition`` when provided.
+            handler: Callable executed when the tool is invoked.
+            class_name: Name of the implementing class.
+
+        Raises:
+            ValueError: If a tool with the same name already exists or if both
+                ``definition`` and ``definition_handler`` are missing.
 
         """
         if name in self.tools:
@@ -54,7 +85,8 @@ class ToolSet:
             "name": name,
         }
 
-    def get_tools(self):
+    def get_tools(self) -> list[dict[str, Any]]:
+        """Return tools that are currently enabled."""
         if not lair.config.get("tools.enabled"):
             return []
 
@@ -67,11 +99,12 @@ class ToolSet:
 
         return enabled_tools
 
-    def all_flags_enabled(self, flags):
+    def all_flags_enabled(self, flags: Iterable[str]) -> bool:
+        """Return ``True`` if all configuration flags evaluate to truthy."""
         return all(lair.config.get(flag) for flag in flags)
 
-    def get_all_tools(self):
-        """Return all tools, adding in an extra 'enabled' field"""
+    def get_all_tools(self) -> list[dict[str, Any]] | None:
+        """Return metadata for all tools with an ``enabled`` field."""
         all_tools = []
         for tool in self.tools.values():
             tool["enabled"] = lair.config.get("tools.enabled") and self.all_flags_enabled(tool["flags"]) is True
@@ -79,14 +112,28 @@ class ToolSet:
 
         return all_tools or None
 
-    def _get_definition(self, tool):
+    def _get_definition(self, tool: dict[str, Any]) -> dict[str, Any]:
+        """Return the structured definition for ``tool``."""
         return tool["definition_handler"]() if tool["definition_handler"] else tool["definition"]
 
-    def get_definitions(self):
+    def get_definitions(self) -> list[dict[str, Any]]:
+        """Return definitions for all enabled tools."""
         tools = self.get_tools()
         return [self._get_definition(tool) for tool in tools]
 
-    def call_tool(self, name, arguments, tool_call_id):
+    def call_tool(self, name: str, arguments: dict[str, Any], tool_call_id: str) -> dict[str, Any]:
+        """Invoke a tool handler with the provided arguments.
+
+        Args:
+            name: The name of the tool to call.
+            arguments: Arguments to pass to the tool handler.
+            tool_call_id: Identifier for the tool call used for logging.
+
+        Returns:
+            A dictionary containing the tool output or an ``error`` key when the
+            call fails or the tool is unknown.
+
+        """
         logger.debug(f"Tool call: {name}({arguments})  [{tool_call_id}]")
         if name not in self.tools:
             return {"error": f"Unknown tool: {name}"}


### PR DESCRIPTION
## Summary
- add missing module and method docs in ToolSet
- refine type hints and use collections.abc imports
- record change in CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair/components/tools/tool_set.py`
- `ruff check lair` *(fails: Found 1223 errors)*
- `ruff format lair`
- `mypy lair` *(fails: Found 31 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c66e1bde08320974a0418b104b610