### PR TITLE
Fix chat module docstrings and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - documentation: Expand README outpainting example
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
+- modules: Add docstrings and type hints to chat module
 
 # v0.8.1 - Bug fixes
 

--- a/lair/modules/chat.py
+++ b/lair/modules/chat.py
@@ -1,14 +1,34 @@
+"""Chat module for the command line interface."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
 import lair
 import lair.cli
-from lair.logging import logger  # noqa
 
 
-def _module_info():
-    return {"description": "Run the interactive Chat interface", "class": Chat, "tags": ["cli"], "aliases": []}
+def _module_info() -> dict[str, Any]:
+    """Return metadata about this module."""
+    return {
+        "description": "Run the interactive Chat interface",
+        "class": Chat,
+        "tags": ["cli"],
+        "aliases": [],
+    }
 
 
 class Chat:
-    def __init__(self, parser):
+    """Interface for starting and managing chat sessions."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        """Initialize the chat subcommand.
+
+        Args:
+            parser: Parser to which chat arguments are added.
+
+        """
         parser.add_argument("-s", "--session", type=str, help="Session id or alias to use.")
         parser.add_argument(
             "-S",
@@ -17,8 +37,15 @@ class Chat:
             help="If an alias provided via --session is not found, create it",
         )
 
-    def run(self, arguments):
+    def run(self, arguments: argparse.Namespace) -> None:
+        """Start the chat interface with the provided arguments.
+
+        Args:
+            arguments: Parsed command line arguments.
+
+        """
         chat = lair.cli.ChatInterface(
-            starting_session_id_or_alias=arguments.session, create_session_if_missing=arguments.allow_create_session
+            starting_session_id_or_alias=arguments.session,
+            create_session_if_missing=arguments.allow_create_session,
         )
         chat.start()


### PR DESCRIPTION
## Summary
- add module docstring and remove unused logger import
- annotate arguments and return types
- document Chat class methods
- update CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair/modules/chat.py`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c675e511c8320bdb6d96826a038a5