### PR TITLE
Improve module loader docs and hints

### DIFF
--- a/lair/module_loader.py
+++ b/lair/module_loader.py
@@ -1,7 +1,10 @@
-import importlib.machinery
+"""Utilities for dynamically loading and validating modules."""
+
+import importlib
 import os
 import re
 import types
+from typing import cast
 
 import jsonschema
 
@@ -9,6 +12,8 @@ from lair.logging import logger
 
 
 class ModuleLoader:
+    """Load modules from disk and expose them as commands."""
+
     MODULE_INFO_SCHEMA = {
         "type": "object",
         "properties": {
@@ -20,12 +25,14 @@ class ModuleLoader:
         "required": ["class"],
     }
 
-    def __init__(self):
-        self.modules = {}
-        self.commands = {}
+    def __init__(self) -> None:
+        """Initialize the loader."""
+        self.modules: dict[str, dict] = {}
+        self.commands: dict[str, type] = {}
 
-    def _get_module_files(self, path):
-        module_files = []
+    def _get_module_files(self, path: str) -> list[str]:
+        """Return all module files contained within ``path``."""
+        module_files: list[str] = []
 
         for root, _dirs, files in os.walk(os.path.abspath(path)):
             for name in files:
@@ -34,20 +41,27 @@ class ModuleLoader:
 
         return module_files
 
-    def _get_module_name(self, module, module_path):
-        """Return the full name of the file by removing the module path and the extension.
+    def _get_module_name(self, module: types.ModuleType, module_path: str) -> str:
+        """Return the module's name relative to ``module_path``.
 
-        Example: `modules/util/tools/example.py` becomes just `util/tools/example`
+        Args:
+            module: Imported module object.
+            module_path: Base directory modules are loaded from.
+
+        Returns:
+            Module name relative to ``module_path`` without the extension.
+
         """
-        absolute_module_file = os.path.abspath(module.__file__).replace("_", "-")
+        absolute_module_file = os.path.abspath(cast(str, module.__file__)).replace("_", "-")
         absolute_module_path = os.path.abspath(module_path)
 
         return re.sub("^" + re.escape(absolute_module_path) + "/", "", re.sub(r"\.pyc?$", "", absolute_module_file))
 
-    def _register_module(self, module, module_path):
+    def _register_module(self, module: types.ModuleType, module_path: str) -> None:
+        """Add ``module`` to the registry after validation."""
         module_info = module._module_info()
         name = self._get_module_name(module, module_path)
-        module_info.update({"name": name})  # Add the name into our stored module_info
+        module_info.update({"name": name})
 
         if name in self.modules:
             raise Exception(f"Unable to register repeat name: {name}")
@@ -63,22 +77,27 @@ class ModuleLoader:
                     raise Exception(f"Unable to register repeat command / alias: {name}")
                 self.commands[alias] = module_info["class"]
 
-    def _validate_module(self, module):
+    def _validate_module(self, module: types.ModuleType) -> None:
+        """Verify that ``module`` contains a valid ``_module_info`` function."""
         if not hasattr(module, "_module_info"):
             raise Exception("_module_info not defined")
-        elif not isinstance(module._module_info, types.FunctionType):
+        if not isinstance(module._module_info, types.FunctionType):
             raise Exception("_module_info not a function")
-        else:
-            try:
-                jsonschema.validate(instance=module._module_info(), schema=ModuleLoader.MODULE_INFO_SCHEMA)
-            except jsonschema.ValidationError as error:
-                raise Exception(f"Invalid _module_info: {error}") from error
 
-    def import_file(self, filename, module_path):
+        try:
+            jsonschema.validate(instance=module._module_info(), schema=ModuleLoader.MODULE_INFO_SCHEMA)
+        except jsonschema.ValidationError as error:
+            raise Exception(f"Invalid _module_info: {error}") from error
+
+    def import_file(self, filename: str, module_path: str) -> None:
+        """Import a Python file and register it as a module."""
         logger.debug(f"Importing file: {filename}")
 
         try:
             spec = importlib.util.spec_from_file_location(filename, filename)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Failed to load spec for {filename}")
+
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 
@@ -88,7 +107,8 @@ class ModuleLoader:
             logger.warning(f"Error loading module from file '{filename}': {error}")
             return
 
-    def load_modules_from_path(self, module_path):
+    def load_modules_from_path(self, module_path: str) -> None:
+        """Load and register all modules found under ``module_path``."""
         logger.debug(f"Loading modules from path: {module_path}")
         files = self._get_module_files(module_path)
 

--- a/lair/modules/__init__.py
+++ b/lair/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in command modules."""


### PR DESCRIPTION
## Summary
- add package docstring for modules package
- document and type ModuleLoader
- validate importlib spec to satisfy mypy

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: D104, ANN201, etc.)*
- `ruff format lair`
- `mypy lair --install-types --non-interactive`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c675318e48320ad5adee2728e8d22