### PR TITLE
Fix argparse docs and typing

### DIFF
--- a/lair/util/__init__.py
+++ b/lair/util/__init__.py
@@ -1,3 +1,10 @@
+"""Utility helpers used across the Lair project.
+
+This module exports various utility functions for interacting with files,
+parsing content, and handling attachments. Importing from this package makes
+these helpers available for reuse in other parts of the code base.
+"""
+
 from lair.util.core import (
     _get_attachments_content__image_file,
     _get_attachments_content__pdf_file,

--- a/lair/util/argparse.py
+++ b/lair/util/argparse.py
@@ -1,13 +1,25 @@
+"""Extensions for Python's ``argparse`` that raise exceptions instead of exiting."""
+
 import argparse
+from typing import IO, TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsWrite as _SupportsWrite
+
+    SupportsWriteStr = _SupportsWrite[str]
+else:
+    SupportsWriteStr = IO[str]
 
 
 class ArgumentParserExitError(Exception):
-    """Custom Exception for argparse to throw on exit, instead of actually exiting"""
+    """Exception raised when the parser attempts to exit."""
 
     pass
 
 
 class ArgumentParserHelpError(Exception):
+    """Exception raised when help output is requested."""
+
     pass
 
 
@@ -17,18 +29,44 @@ ArgumentParserHelpException = ArgumentParserHelpError
 
 
 class ErrorRaisingArgumentParser(argparse.ArgumentParser):
-    """Custom ArgumentParser() that throws exceptions so that behaviors could be handled differently"""
+    """ArgumentParser that raises exceptions instead of exiting."""
 
-    def error(self, message):
-        """Throw ArgumentError() on errors"""
+    def error(self, message: str) -> NoReturn:
+        """Raise :class:`argparse.ArgumentError` instead of exiting.
+
+        Args:
+            message: The error message to display.
+
+        Raises:
+            argparse.ArgumentError: Always raised with ``message``.
+
+        """
         raise argparse.ArgumentError(None, message)
 
-    def exit(self, status=0, message=None):
-        """Instead of exiting, throw an exception with the error"""
+    def exit(self, status: int = 0, message: str | None = None) -> NoReturn:
+        """Raise :class:`ArgumentParserExitError` instead of exiting.
+
+        Args:
+            status: Exit status code. This value is ignored.
+            message: Optional exit message to print before raising.
+
+        Raises:
+            ArgumentParserExitError: Always raised to signal a parser exit.
+
+        """
         if message:
             self._print_message(message)
         raise ArgumentParserExitError(None, None)
 
-    def print_help(self, file=None):
-        """Override print_help to raise an exception with the help message."""
+    def print_help(self, file: SupportsWriteStr | None = None) -> NoReturn:
+        """Raise :class:`ArgumentParserHelpError` with formatted help text.
+
+        Args:
+            file: Unused file handle provided for compatibility with the base
+                class.
+
+        Raises:
+            ArgumentParserHelpError: Always raised with the formatted help text.
+
+        """
         raise ArgumentParserHelpError(self.format_help())


### PR DESCRIPTION
## Summary
- document util package
- improve ArgumentParser extension docstrings and typing

## Testing
- `python -m compileall -q lair`
- `ruff check lair/util/__init__.py lair/util/argparse.py`
- `ruff format lair/util/__init__.py lair/util/argparse.py`
- `mypy lair/util/__init__.py lair/util/argparse.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c67fb55108320a443590fdff79748