### PR TITLE
Improve comfy module docs and types

### DIFF
--- a/lair/modules/comfy.py
+++ b/lair/modules/comfy.py
@@ -1,14 +1,19 @@
+"""Command line interface for running ComfyUI workflows."""
+
 import argparse
 import os
 import pathlib
 import shlex
 import sys
+from collections.abc import Iterable, Sequence
+from typing import Any, cast
 
 import PIL
 
 import lair
 import lair.cli
 import lair.comfy_caller
+from lair.cli.chat_interface import ChatInterface
 from lair.logging import logger  # noqa
 from lair.util.argparse import (
     ArgumentParserExitException,
@@ -17,12 +22,21 @@ from lair.util.argparse import (
 )
 
 
-def _module_info():
-    return {"description": "Run ComfyUI workflows", "class": Comfy, "tags": [], "aliases": []}
+def _module_info() -> dict[str, Any]:
+    """Return metadata describing this module."""
+    return {
+        "description": "Run ComfyUI workflows",
+        "class": Comfy,
+        "tags": [],
+        "aliases": [],
+    }
 
 
 class Comfy:
-    def __init__(self, parser):
+    """Entry point for the ``comfy`` command."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        """Initialize the argument parser for all ComfyUI workflows."""
         sub_parser = parser.add_subparsers(dest="comfy_command", required=True)
 
         self.comfy = lair.comfy_caller.ComfyCaller()
@@ -37,7 +51,7 @@ class Comfy:
 
         lair.events.subscribe("chat.init", lambda d: self._on_chat_init(d), instance=self)
 
-    def _add_argparse_image(self, sub_parser):
+    def _add_argparse_image(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("image", help="Basic image creation workflow")
         defaults = self.comfy.defaults["image"]
         output_file = lair.config.get("comfy.image.output_file")
@@ -120,7 +134,7 @@ class Comfy:
             ),
         )
 
-    def _add_argparse_hunyuan_video_t2v(self, sub_parser):
+    def _add_argparse_hunyuan_video_t2v(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("hunyuan-video-t2v", help="Hunyuan Video - Text to Video")
         defaults = self.comfy.defaults["hunyuan-video-t2v"]
         output_file = lair.config.get("comfy.hunyuan_video.output_file")
@@ -225,7 +239,7 @@ class Comfy:
             ),
         )
 
-    def _add_argparse_ltxv_i2v(self, sub_parser):
+    def _add_argparse_ltxv_i2v(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("ltxv-i2v", help="LTX Video - Image to Video")
         defaults = self.comfy.defaults["ltxv-i2v"]
         output_file = lair.config.get("comfy.ltxv_i2v.output_file")
@@ -342,7 +356,7 @@ class Comfy:
             ),
         )
 
-    def _add_argparse_ltxv_prompt(self, sub_parser):
+    def _add_argparse_ltxv_prompt(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("ltxv-prompt", help="LTX Video - Generate prompts from an image")
         defaults = self.comfy.defaults["ltxv-prompt"]
         output_file = lair.config.get("comfy.ltxv_prompt.output_file")
@@ -382,7 +396,7 @@ class Comfy:
             ),
         )
 
-    def _add_argparse_outpaint(self, sub_parser):
+    def _add_argparse_outpaint(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("outpaint", help="Outpaint images")
         defaults = self.comfy.defaults["outpaint"]
         comfy_url = lair.config.get("comfy.url")
@@ -469,7 +483,7 @@ class Comfy:
         )
         command_parser.add_argument("outpaint_files", type=str, nargs="+", help="File(s) to outpaint")
 
-    def _add_argparse_upscale(self, sub_parser):
+    def _add_argparse_upscale(self, sub_parser: argparse._SubParsersAction) -> None:
         command_parser = sub_parser.add_parser("upscale", help="Upscale images")
         defaults = self.comfy.defaults["upscale"]
         comfy_url = lair.config.get("comfy.url")
@@ -490,8 +504,8 @@ class Comfy:
         )
         command_parser.add_argument("scale_files", type=str, nargs="+", help="File(s) to scale")
 
-    def _get_chat_command_parser(self):
-        """Create a parser that can be used for parsing for chat commands without exiting on errors"""
+    def _get_chat_command_parser(self) -> argparse.ArgumentParser:
+        """Return an ``ArgumentParser`` for the ``/comfy`` chat command."""
         new_parser = ErrorRaisingArgumentParser(prog="/comfy")
         sub_parser = new_parser.add_subparsers(dest="comfy_command", required=True)
 
@@ -503,8 +517,11 @@ class Comfy:
 
         return new_parser
 
-    def _on_chat_init(self, chat_interface):
-        def comfy_command(command, arguments, arguments_str):
+    def _on_chat_init(self, chat_interface: "ChatInterface") -> None:
+        """Register the ``/comfy`` command with the chat interface."""
+
+        def comfy_command(command: str, arguments: Iterable[str], arguments_str: str) -> None:
+            """Execute a ComfyUI workflow from the chat interface."""
             try:
                 chat_command_parser = self._get_chat_command_parser()
                 new_arguments = shlex.split(" ".join(arguments))
@@ -529,11 +546,16 @@ class Comfy:
 
         chat_interface.register_command("/comfy", comfy_command, "Call ComfyUI workflows")
 
-    def _save_output__save_to_disk(self, item, filename):
-        """Save the given item to disk. Supports PIL.Image and HTTP response.raw objects.
+    def _save_output__save_to_disk(self, item: object, filename: str) -> None:
+        """Save a workflow output to disk.
 
-        :param item: The item to save (PIL.Image.Image or HTTP response.raw).
-        :param filename: The file path to save the item to.
+        Args:
+            item: The object to save. ``PIL.Image.Image`` and file-like objects are supported.
+            filename: Path on disk where the item should be saved.
+
+        Raises:
+            TypeError: If ``item`` is not a supported type.
+
         """
         if isinstance(item, PIL.Image.Image):
             item.save(filename)
@@ -547,20 +569,27 @@ class Comfy:
         else:
             raise TypeError("Unsupported output type. Unable to save output file.")
 
-    def _save_output(self, results, filename, start_index=0, single_output=False):
-        """Saves a list of outputs to disk.
+    def _save_output(
+        self,
+        results: Sequence[object],
+        filename: str,
+        start_index: int = 0,
+        single_output: bool = False,
+    ) -> None:
+        """Save workflow outputs to disk.
 
         Args:
-            results (list): List of outputs to be saved.
-            filename (str): Base filename to save the outputs. If multiple outputs, filenames
-                            will increment as {basename}{x}.{extension}.
+            results: Items returned from the workflow.
+            filename: Base filename for saving outputs.
+            start_index: Index offset when naming multiple outputs.
+            single_output: Whether ``results`` contains exactly one item.
 
         """
         output_files = []
 
         if single_output:  # Save single output with provided filename
             if filename == "-":
-                sys.stdout.buffer.write(results[0] + b"\n")
+                sys.stdout.buffer.write(cast(bytes, results[0]) + b"\n")
                 return
 
             self._save_output__save_to_disk(results[0], filename)
@@ -582,10 +611,20 @@ class Comfy:
 
         logger.debug(f"saved: {', '.join(output_files)}")
 
-    def get_output_file_name(self, file_name):
+    def get_output_file_name(self, file_name: str) -> str:
+        """Return the filename that should be used for an upscaled image."""
         return f"{os.path.splitext(file_name)[0]}-upscaled{os.path.splitext(file_name)[1]}"
 
-    def _run_workflow_queue(self, arguments, defaults, function_arguments, *, queue, output_filename_template):
+    def _run_workflow_queue(
+        self,
+        arguments: argparse.Namespace,
+        defaults: dict[str, Any],
+        function_arguments: dict[str, Any],
+        *,
+        queue: list[str],
+        output_filename_template: str,
+    ) -> None:
+        """Process each file in ``queue`` using the provided workflow."""
         while queue:
             source_filename = queue.pop(0)
             if os.path.isdir(source_filename):
@@ -596,13 +635,21 @@ class Comfy:
             else:
                 self._process_file(source_filename, arguments, function_arguments, output_filename_template)
 
-    def _extend_queue_from_dir(self, directory, queue):
+    def _extend_queue_from_dir(self, directory: str, queue: list[str]) -> None:
+        """Add image files from ``directory`` to ``queue``."""
         for filename in os.listdir(directory):
             path = pathlib.Path(directory) / filename
             if path.is_dir() or path.suffix.lower() in self._image_file_extensions:
                 queue.append(str(path.absolute()))
 
-    def _process_file(self, filename, arguments, function_arguments, template):
+    def _process_file(
+        self,
+        filename: str,
+        arguments: argparse.Namespace,
+        function_arguments: dict[str, Any],
+        template: str,
+    ) -> None:
+        """Run a workflow for a single file and save the result."""
         function_arguments["source_image"] = filename
         output_filename = template.format(basename=os.path.splitext(filename)[0])
 
@@ -615,7 +662,13 @@ class Comfy:
             raise ValueError("Workflow returned no output. This could indicate an invalid parameter was provided.")
         self._save_output(output, output_filename, single_output=True)
 
-    def run_workflow_outpaint(self, arguments, defaults, function_arguments):
+    def run_workflow_outpaint(
+        self,
+        arguments: argparse.Namespace,
+        defaults: dict[str, Any],
+        function_arguments: dict[str, Any],
+    ) -> None:
+        """Run the outpaint workflow for each file in ``arguments.outpaint_files``."""
         if arguments.padding:
             components = arguments.padding.split("x")
             if len(components) != 4:
@@ -639,7 +692,13 @@ class Comfy:
             output_filename_template=lair.config.get("comfy.outpaint.output_filename"),
         )
 
-    def run_workflow_upscale(self, arguments, defaults, function_arguments):
+    def run_workflow_upscale(
+        self,
+        arguments: argparse.Namespace,
+        defaults: dict[str, Any],
+        function_arguments: dict[str, Any],
+    ) -> None:
+        """Run the upscale workflow for each file in ``arguments.scale_files``."""
         self._run_workflow_queue(
             arguments,
             defaults,
@@ -648,7 +707,13 @@ class Comfy:
             output_filename_template=lair.config.get("comfy.upscale.output_filename"),
         )
 
-    def run_workflow_default(self, arguments, defaults, function_arguments):
+    def run_workflow_default(
+        self,
+        arguments: argparse.Namespace,
+        defaults: dict[str, Any],
+        function_arguments: dict[str, Any],
+    ) -> None:
+        """Run a workflow and save outputs, respecting ``arguments.repeat``."""
         # True when there is only a single file output
         batch_size = function_arguments.get("batch_size", defaults.get("batch_size", 1))
         single_output = arguments.repeat == 1 and batch_size == 1
@@ -660,7 +725,8 @@ class Comfy:
                 raise ValueError("Workflow returned no output. This could indicate an invalid parameter was provided.")
             self._save_output(output, arguments.output_file, i * len(output), single_output=single_output)
 
-    def run(self, arguments):
+    def run(self, arguments: argparse.Namespace) -> None:
+        """Execute a workflow based on parsed command-line ``arguments``."""
         self.comfy.set_url(arguments.comfy_url)
 
         arguments_dict = vars(arguments)


### PR DESCRIPTION
## Summary
- add module docstring for `comfy` module
- document class `Comfy` and its methods
- annotate function parameters and return values
- clean up docstring style

## Testing
- `python -m compileall -q lair`
- `ruff check lair/modules/comfy.py`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c676eb9fc832090919ddba865c7d2