### PR TITLE
Improve logging docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - documentation: Expand README outpainting example
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
+- internal: Add structured docstrings and type hints for logging utilities
 
 # v0.8.1 - Bug fixes
 

--- a/lair/logging.py
+++ b/lair/logging.py
@@ -1,5 +1,10 @@
+"""Colorized logging utilities used throughout Lair."""
+
+from __future__ import annotations
+
 import logging
 import sys
+from typing import Any, cast
 
 from rich.console import Console
 from rich.text import Text
@@ -8,13 +13,21 @@ logger = logging.getLogger("lair")
 console = Console()
 
 
-def init_logging(enable_debugging=False):
+def init_logging(enable_debugging: bool = False) -> None:
+    """Configure the ``lair`` logger.
+
+    Args:
+        enable_debugging: If ``True``, set the log level to ``DEBUG``. Otherwise ``INFO``.
+
+    """
     handler = logging.StreamHandler()
 
     class LairLogFilter(logging.Filter):
-        def filter(self, record):
-            record.color = _log_color(record.levelname)
-            record.prefix = f"{record.levelname}: " if record.levelname != "INFO" else ""
+        """Add color and prefix attributes to log records."""
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            cast(Any, record).color = _log_color(record.levelname)
+            cast(Any, record).prefix = f"{record.levelname}: " if record.levelname != "INFO" else ""
             return True
 
     handler.setFormatter(logging.Formatter("%(message)s"))
@@ -22,15 +35,17 @@ def init_logging(enable_debugging=False):
     logger.addFilter(LairLogFilter())
     logger.setLevel("DEBUG" if enable_debugging else "INFO")
 
-    def exit_error(*args, **kwargs):
-        logger.error(*args, **kwargs)
+    def exit_error(*args: object, **kwargs: object) -> None:
+        """Log an error message and exit with status 1."""
+        logger.error(*cast(Any, args), **cast(Any, kwargs))
         sys.exit(1)
 
-    handler.emit = lambda record: _emit_with_color(handler, record)
-    logger.exit_error = exit_error
+    cast(Any, handler).emit = lambda record: _emit_with_color(handler, record)
+    cast(Any, logger).exit_error = exit_error
 
 
-def _log_color(level_name):
+def _log_color(level_name: str) -> str | None:
+    """Return the rich color for a log level."""
     if level_name == "ERROR":
         return "red"
     if level_name == "DEBUG":
@@ -40,7 +55,10 @@ def _log_color(level_name):
     return None
 
 
-def _emit_with_color(handler, record):
+def _emit_with_color(handler: logging.Handler, record: logging.LogRecord) -> None:
+    """Emit a log record using ``rich`` for colorized output."""
     message = handler.format(record)
-    text = Text(record.prefix + message, style=record.color) if record.color else Text(record.prefix + message)
+    prefix = cast(Any, record).prefix
+    color = cast(Any, record).color
+    text = Text(prefix + message, style=color) if color else Text(prefix + message)
     console.print(text)


### PR DESCRIPTION
## Summary
- add module documentation for logging utilities
- type and document logging functions

## Testing
- `python -m compileall -q lair`
- `ruff check lair/logging.py`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6704ff1483209925b89f0259e165