### PR TITLE
Fix prompt template docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - documentation: Expand README outpainting example
 - cleanup: refactor workflow and tool call helpers for readability
 - internal: Enforce strict ruff checks, ruff formatting, and mypy validation
+- util: Add documentation and type hints to prompt template
 
 # v0.8.1 - Bug fixes
 

--- a/lair/util/prompt_template.py
+++ b/lair/util/prompt_template.py
@@ -1,3 +1,5 @@
+"""Utilities for expanding Jinja2 templates used in prompts."""
+
 from datetime import datetime, timezone
 
 import jinja2
@@ -5,7 +7,16 @@ import jinja2
 import lair
 
 
-def fill(prompt_template):
+def fill(prompt_template: str) -> str:
+    """Render a template using predefined context variables.
+
+    Args:
+        prompt_template: The Jinja2 template string to be rendered.
+
+    Returns:
+        The rendered template string.
+
+    """
     template = jinja2.Template(prompt_template)
 
     utc_now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- document util.prompt_template module and add type hints
- update changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair/util/prompt_template.py`
- `mypy lair/util/prompt_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6829da348320b5c13b32caec0dc4