### PR TITLE
Fix docs and typing for chat interface commands

### DIFF
--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -1,8 +1,12 @@
+"""Chat interface command implementations."""
+
 import json
 import os
 import shlex
+from typing import Any, Callable
 
 import lair
+import lair.sessions as sessions
 from lair.logging import logger
 from lair.util.argparse import (
     ArgumentParserExitError,
@@ -21,7 +25,36 @@ ArgumentParserHelpException = _ArgumentParserHelpException
 
 
 class ChatInterfaceCommands:
-    def _get_commands(self):
+    """Mixin providing all command handlers for the chat interface."""
+
+    # These attributes are provided by ``ChatInterface`` at runtime.
+    commands: dict[str, dict[str, Any]]
+    reporting: Any
+    chat_session: Any
+    session_manager: Any
+
+    # Method placeholders implemented in parent classes.
+    _get_embedded_response: Callable[..., Any]
+    print_help: Callable[..., None]
+    print_history: Callable[..., None]
+    print_models_report: Callable[..., None]
+    print_config_report: Callable[..., None]
+    print_tools_report: Callable[..., None]
+    _rebuild_chat_session: Callable[..., None]
+    print_modes_report: Callable[..., None]
+    print_current_model_report: Callable[..., None]
+    print_sessions_report: Callable[..., None]
+    _switch_to_session: Callable[..., None]
+    _new_chat_session: Callable[..., None]
+
+    def _get_commands(self) -> dict[str, dict[str, Any]]:
+        """Return a mapping of command definitions.
+
+        Returns:
+            dict[str, dict[str, Any]]: Mapping of command names to command
+            metadata including callbacks and descriptions.
+
+        """
         return {
             "/clear": {
                 "callback": lambda command, arguments, arguments_str: self.command_clear(
@@ -186,7 +219,20 @@ class ChatInterfaceCommands:
             },
         }
 
-    def register_command(self, command, callback, description):
+    def register_command(
+        self,
+        command: str,
+        callback: Callable[[str, list[str], str], None],
+        description: str,
+    ) -> None:
+        """Register a new chat command.
+
+        Args:
+            command: The command string, including the leading ``/``.
+            callback: Function called when the command is executed.
+            description: Text displayed in ``/help`` output.
+
+        """
         # Other modules can subscribe to chat.init() and then call
         # this function to register their own sub-commands.
         if command in self.commands:
@@ -197,7 +243,23 @@ class ChatInterfaceCommands:
             "description": description,
         }
 
-    def command_clear(self, command, arguments, arguments_str):
+    def command_clear(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Clear the current conversation history.
+
+        Args:
+            command: The raw command string.
+            arguments: Command arguments split by whitespace.
+            arguments_str: The original argument string.
+
+        Returns:
+            None
+
+        """
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /clear takes no arguments")
         else:
@@ -205,7 +267,23 @@ class ChatInterfaceCommands:
             self.chat_session.session_title = None
             self.reporting.system_message("Conversation history cleared")
 
-    def command_debug(self, command, arguments, arguments_str):
+    def command_debug(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Toggle debugging output verbosity.
+
+        Args:
+            command: The raw command string.
+            arguments: Command arguments split by whitespace.
+            arguments_str: The original argument string.
+
+        Returns:
+            None
+
+        """
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /debug takes no arguments")
         else:
@@ -216,7 +294,23 @@ class ChatInterfaceCommands:
                 logger.setLevel("DEBUG")
                 self.reporting.system_message("Debugging enabled")
 
-    def command_extract(self, command, arguments, arguments_str):
+    def command_extract(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Extract a section from the last response.
+
+        Args:
+            command: The raw command string.
+            arguments: Command arguments split by whitespace.
+            arguments_str: The original argument string.
+
+        Returns:
+            None
+
+        """
         if len(arguments) > 2:
             self.reporting.user_error("ERROR: usage: /extract [position?] [filename?]")
         else:
@@ -242,19 +336,47 @@ class ChatInterfaceCommands:
             else:
                 logger.error("Extract failed: Last response is not set")
 
-    def command_help(self, command, arguments, arguments_str):
+    def command_help(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Display help for available commands.
+
+        Args:
+            command: The raw command string.
+            arguments: Command arguments split by whitespace.
+            arguments_str: The original argument string.
+
+        Returns:
+            None
+
+        """
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /help takes no arguments")
         else:
             self.print_help()
 
-    def command_history(self, command, arguments, arguments_str):
+    def command_history(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Print the entire conversation history."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /history takes no arguments")
         else:
             self.print_history()
 
-    def command_history_edit(self, command, arguments, arguments_str):
+    def command_history_edit(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Edit the conversation history in an external editor."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /history-edit takes no arguments")
         else:
@@ -274,7 +396,13 @@ class ChatInterfaceCommands:
             else:
                 self.reporting.user_error("History was not modified.")
 
-    def command_history_slice(self, command, arguments, arguments_str):
+    def command_history_slice(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Replace history with a Python slice of the existing messages."""
         if len(arguments) != 1:
             self.reporting.user_error("ERROR: Invalid arguments: Usage: /history-slice [slice]")
         else:
@@ -288,7 +416,13 @@ class ChatInterfaceCommands:
                 f"History updated  (Selected {new_num_messages} messages out of {original_num_messages})"
             )
 
-    def command_last_prompt(self, command, arguments, arguments_str):
+    def command_last_prompt(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show or save the most recent prompt."""
         if len(arguments) > 1:
             self.reporting.user_error("ERROR: Invalid arguments: Usage: /last-prompt [filename?]")
         else:
@@ -303,7 +437,13 @@ class ChatInterfaceCommands:
             else:
                 logger.warning("No last prompt found")
 
-    def command_last_response(self, command, arguments, arguments_str):
+    def command_last_response(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Display or save the most recent response."""
         if len(arguments) > 1:
             self.reporting.user_error("ERROR: Invalid arguments: Usage: /last-response [filename?]")
         else:
@@ -318,13 +458,25 @@ class ChatInterfaceCommands:
             else:
                 logger.warning("No last response found")
 
-    def command_list_models(self, command, arguments, arguments_str):
+    def command_list_models(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """List available models for the current session."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /list-models takes no arguments")
         else:
             self.print_models_report(update_cache=True)
 
-    def command_list_settings(self, command, arguments, arguments_str):
+    def command_list_settings(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """List configuration settings."""
         parser = ErrorRaisingArgumentParser(prog="/list-settings")
         parser.add_argument(
             "-b",
@@ -351,13 +503,25 @@ class ChatInterfaceCommands:
             filter_regex=new_arguments.search,
         )
 
-    def command_list_tools(self, command, arguments, arguments_str):
+    def command_list_tools(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Display all known tools and their status."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /list-tools takes no arguments")
         else:
             self.print_tools_report()
 
-    def command_load(self, command, arguments, arguments_str):
+    def command_load(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Load a chat session from disk."""
         filename = "chat_session.json" if len(arguments) == 0 else os.path.expanduser(arguments[0])
         with lair.events.defer_events():
             current_session_id = self.chat_session.session_id  # Preserve to overwrite the current session
@@ -371,7 +535,13 @@ class ChatInterfaceCommands:
             self._rebuild_chat_session()
             self.reporting.system_message(f"Session loaded from {filename}")
 
-    def command_messages(self, command, arguments, arguments_str):
+    def command_messages(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show or save the message history."""
         if len(arguments) > 1:
             self.reporting.user_error("ERROR: Invalid arguments: Usage /messages [filename?]")
         else:
@@ -390,18 +560,30 @@ class ChatInterfaceCommands:
                 for message in messages:
                     self.reporting.print_highlighted_json(json.dumps(message))
 
-    def command_mode(self, command, arguments, arguments_str):
+    def command_mode(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show or change the current mode."""
         if len(arguments) == 0:
             self.print_modes_report()
         elif len(arguments) == 1:  # Set mode
             lair.config.change_mode(arguments[0])
             old_session = self.chat_session
-            self.chat_session = lair.sessions.get_chat_session(lair.config.get("session.type"))
+            self.chat_session = sessions.get_chat_session(lair.config.get("session.type"))
             self.chat_session.import_state(old_session)
         else:
             self.reporting.user_error("ERROR: Invalid arguments: Usage: /mode [name?]")
 
-    def command_model(self, command, arguments, arguments_str):
+    def command_model(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show or set the active model."""
         if len(arguments) > 1:
             self.reporting.user_error("ERROR: Invalid arguments: Usage /model [name?]")
         elif len(arguments) == 0:
@@ -409,25 +591,49 @@ class ChatInterfaceCommands:
         elif len(arguments) == 1:
             lair.config.set("model.name", arguments[0])
 
-    def command_prompt(self, command, arguments, arguments_str):
+    def command_prompt(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show or update the system prompt."""
         if len(arguments) == 0:
             self.reporting.system_message(lair.config.get("session.system_prompt_template"))
         else:
             lair.config.set("session.system_prompt_template", arguments_str)
 
-    def command_reload_settings(self, command, arguments, arguments_str):
+    def command_reload_settings(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Reload configuration from disk."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: USAGE: /reload_settings")
         else:
             lair.config.reload()
             self.reporting.system_message("Settings reloaded from disk")
 
-    def command_save(self, command, arguments, arguments_str):
+    def command_save(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Save the current session to disk."""
         filename = "chat_session.json" if len(arguments) == 0 else os.path.expanduser(arguments[0])
         self.chat_session.save_to_file(filename)
         self.reporting.system_message(f"Session written to {filename}")
 
-    def command_session(self, command, arguments, arguments_str):
+    def command_session(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """List sessions or switch to another session."""
         if len(arguments) == 0:
             self.print_sessions_report()
         elif len(arguments) == 1:
@@ -436,7 +642,13 @@ class ChatInterfaceCommands:
         else:
             self.reporting.user_error("ERROR: USAGE: /session [session_id|alias?]")
 
-    def command_session_alias(self, command, arguments, arguments_str):
+    def command_session_alias(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Set or remove a session alias."""
         if len(arguments) != 1 and len(arguments) != 2:
             self.reporting.user_error(
                 "ERROR: Invalid arguments: Usage /session-alias [session_id|alias?] [new_alias?])"
@@ -453,7 +665,13 @@ class ChatInterfaceCommands:
             else:
                 self.reporting.user_error("ERROR: That alias is unavailable")
 
-    def command_session_delete(self, command, arguments, arguments_str):
+    def command_session_delete(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Delete one or more sessions."""
         if len(arguments) == 0:
             self.reporting.user_error("ERROR: Invalid arguments: Usage /session-delete [session_id|alias?]...)")
         else:
@@ -462,17 +680,29 @@ class ChatInterfaceCommands:
             # If the current session was deleted, recreate it
             try:
                 self.session_manager.get_session_id(self.chat_session.session_id)
-            except lair.sessions.session_manager.UnknownSessionException:
+            except sessions.session_manager.UnknownSessionException:
                 self._new_chat_session()
 
-    def command_session_new(self, command, arguments, arguments_str):
+    def command_session_new(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Create a new session."""
         if len(arguments) != 0:
             self.reporting.user_error("ERROR: /session-new takes no arguments")
         else:
             self._new_chat_session()
             self.reporting.system_message("New session created")
 
-    def command_session_title(self, command, arguments, arguments_str):
+    def command_session_title(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Set or clear a session title."""
         if len(arguments) == 0:
             self.reporting.user_error(
                 "ERROR: Invalid arguments: Usage /session-title [session_id|alias?] [new_title?])"
@@ -484,7 +714,13 @@ class ChatInterfaceCommands:
                 self.chat_session.session_title = new_title
             self.session_manager.set_title(session_id, new_title)
 
-    def command_set(self, command, arguments, arguments_str):
+    def command_set(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Show configuration or set a configuration value."""
         if len(arguments) == 0:
             self.print_config_report()
         else:


### PR DESCRIPTION
## Summary
- add module docstring and type hints for `chat_interface_commands`
- document ChatInterfaceCommands mixin and declare expected attributes
- implement structured docstrings for command handlers
- type annotate command parameters and return values

## Testing
- `python -m compileall -q lair`
- `ruff check lair/cli/chat_interface_commands.py`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c665005208320bd7f50c8f810cab4