### PR TITLE
Improve docstrings & typing for util.core

### DIFF
--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -1,3 +1,7 @@
+"""Utility helpers used across the Lair project."""
+
+from __future__ import annotations
+
 import base64
 import datetime
 import glob
@@ -11,7 +15,7 @@ import re
 import shlex
 import subprocess
 import tempfile
-from typing import Optional
+from typing import TypeVar
 
 import pdfplumber
 import yaml
@@ -19,31 +23,68 @@ import yaml
 import lair
 from lair.logging import logger
 
+T = TypeVar("T")
+
 subprocess_run = subprocess.run
 
 
-def safe_dump_json(document):
-    def fix_date(x):
+def safe_dump_json(document: object) -> str:
+    """Serialize a document to JSON while handling ``datetime`` objects.
+
+    Args:
+        document: Any JSON serializable structure.
+
+    Returns:
+        A JSON string representation of ``document``.
+
+    """
+
+    def fix_date(x: object) -> object:
         return str(x) if isinstance(x, datetime.datetime) else x
 
     return json.dumps(document, default=fix_date)
 
 
-def safe_int(number):
+def safe_int(number: str | int | float) -> int | str | float:
+    """Convert a value to ``int`` if possible.
+
+    Args:
+        number: Value to convert.
+
+    Returns:
+        ``int`` when conversion succeeds, otherwise the original ``number``.
+
+    """
     try:
         return int(number)
     except Exception:
         return number
 
 
-def slurp_file(filename):
+def slurp_file(filename: str) -> str:
+    """Read a file and return its contents.
+
+    Args:
+        filename: Path to the file. ``~`` expansion is supported.
+
+    Returns:
+        The content of the file.
+
+    """
     with open(os.path.expanduser(filename)) as fd:
         document = fd.read()
 
     return document
 
 
-def save_file(filename, contents):
+def save_file(filename: str, contents: str) -> None:
+    """Write ``contents`` to ``filename``.
+
+    Args:
+        filename: Destination path. ``~`` expansion is supported.
+        contents: Text to write to the file.
+
+    """
     with open(os.path.expanduser(filename), "w") as fd:
         fd.write(contents)
 
@@ -54,59 +95,100 @@ def parse_yaml_text(text: str) -> dict:
     return data or {}
 
 
-def parse_yaml_file(filename):
+def parse_yaml_file(filename: str) -> dict:
+    """Read a YAML file from disk.
+
+    Args:
+        filename: Path to the YAML file.
+
+    Returns:
+        Parsed YAML data as a dictionary.
+
+    """
     with open(filename) as fd:
         contents = fd.read()
     return parse_yaml_text(contents)
 
 
-def load_json_file(filename):
+def load_json_file(filename: str) -> object:
+    """Load JSON data from a file."""
     return json.loads(slurp_file(filename))
 
 
-def save_json_file(filename, document):
+def save_json_file(filename: str, document: object) -> None:
+    """Serialize ``document`` to JSON and save it to ``filename``."""
     json_document = safe_dump_json(document)
 
     with open(filename, "w") as fd:
         fd.write(json_document)
 
 
-def get_lib_path(end=""):
-    """Return the path to the recon library."""
+def get_lib_path(end: str = "") -> str:
+    """Return the path to the library directory.
+
+    Args:
+        end: Optional suffix to append to the base path.
+
+    Returns:
+        The absolute path to the requested location.
+
+    """
     return os.path.dirname(__file__) + "/../" + end
 
 
-def read_package_file(path, name):
-    """Read a file within the packages libdir.
-    path - Package path (dot delimited, such as lair.files)
-    name - Filename within the path
+def read_package_file(path: str, name: str) -> str:
+    """Read a file bundled with the package.
+
+    Args:
+        path: Dot-delimited package path, e.g. ``"lair.files"``.
+        name: Filename within the package.
+
+    Returns:
+        The file contents as a string.
+
     """
     with importlib.resources.open_text(path, name) as fd:
         return fd.read()
 
 
-def get_log_level():
+def get_log_level() -> str:
+    """Return the current log level name."""
     return logging.getLevelName(logger.level)
 
 
-def is_debug_enabled():
+def is_debug_enabled() -> bool:
+    """Check whether debug logging is enabled."""
     return logger.getEffectiveLevel() <= logging.DEBUG
 
 
-def strip_escape_codes(content):
+def strip_escape_codes(content: str) -> str:
+    """Remove ANSI escape codes from ``content``."""
     return re.sub(r"\033\[[0-9;?]*[a-zA-Z]", "", content)
 
 
-def get_message(role, message):
+def get_message(role: str, message: str) -> dict[str, str]:
+    """Create a structured chat message."""
     return {
         "role": role,
         "content": message,
     }
 
 
-def expand_filename_list(filenames, *, fail_on_not_found=True, sort_results=True):
-    """Expand user and globs in filenames and return the expanded list"""
-    new_filenames = []
+def expand_filename_list(
+    filenames: list[str], *, fail_on_not_found: bool = True, sort_results: bool = True
+) -> list[str]:
+    """Expand user paths and globs.
+
+    Args:
+        filenames: A list of filename patterns.
+        fail_on_not_found: Raise ``Exception`` when no matches are found.
+        sort_results: Whether to sort the resulting list.
+
+    Returns:
+        List of expanded filenames.
+
+    """
+    new_filenames: list[str] = []
 
     for filename in filenames:
         matches = glob.glob(os.path.expanduser(filename))
@@ -119,12 +201,21 @@ def expand_filename_list(filenames, *, fail_on_not_found=True, sort_results=True
     return sorted(new_filenames) if sort_results else new_filenames
 
 
-def _get_attachments_content__image_file(filename):
+def _get_attachments_content__image_file(filename: str) -> list[dict[str, object]]:
+    """Return image parts for an attachment.
+
+    Args:
+        filename: Path to the image file.
+
+    Returns:
+        A list of content parts suitable for OpenAI image attachments.
+
+    """
     mime_type = mimetypes.guess_type(filename)[0]  # Extract the MIME type
     if not mime_type or not mime_type.startswith("image/"):
         raise ValueError(f"File has image extension, but non-image mime type: {filename}  (mime={mime_type})")
 
-    parts = []
+    parts: list[dict[str, object]] = []
     with open(filename, "rb") as fd:
         if lair.config.get("misc.provide_attachment_filenames"):
             parts.append({"type": "text", "text": f"Attached File: {filename} ({mime_type})"})
@@ -142,7 +233,17 @@ def _get_attachments_content__image_file(filename):
     return parts
 
 
-def read_pdf(filename, *, enforce_limits=False):
+def read_pdf(filename: str, *, enforce_limits: bool = False) -> str:
+    """Extract text from a PDF file.
+
+    Args:
+        filename: Path to the PDF file.
+        enforce_limits: Whether to stop reading when the configured limit is exceeded.
+
+    Returns:
+        The extracted text.
+
+    """
     limit = lair.config.get("misc.text_attachment_max_size")
 
     with pdfplumber.open(filename) as pdf_reader:
@@ -166,7 +267,16 @@ def read_pdf(filename, *, enforce_limits=False):
     return contents
 
 
-def _get_attachments_content__pdf_file(filename):
+def _get_attachments_content__pdf_file(filename: str) -> dict[str, str]:
+    """Create a chat message from a PDF attachment.
+
+    Args:
+        filename: Path to the PDF file.
+
+    Returns:
+        A message dictionary suitable for sending to the chat API.
+
+    """
     contents = read_pdf(filename)
 
     if lair.config.get("misc.provide_attachment_filenames"):
@@ -177,7 +287,16 @@ def _get_attachments_content__pdf_file(filename):
     return lair.util.get_message("user", header + contents)
 
 
-def _get_attachments_content__text_file(filename):
+def _get_attachments_content__text_file(filename: str) -> dict[str, str]:
+    """Create a chat message from a text attachment.
+
+    Args:
+        filename: Path to the text file.
+
+    Returns:
+        A message dictionary containing the file text.
+
+    """
     limit = lair.config.get("misc.text_attachment_max_size")
     do_truncate = False
     if os.path.getsize(filename) > limit:
@@ -205,19 +324,21 @@ def _get_attachments_content__text_file(filename):
     return lair.util.get_message("user", header + contents)
 
 
-def get_attachments_content(filenames):
-    """Take a list of filenames and return the content
-    Parameters:
-        filenames: A list of filenames to generate attachments for. Globs and homedir
-            expansion are supported.
+def get_attachments_content(
+    filenames: list[str],
+) -> tuple[list[dict[str, object]], list[dict[str, str]]]:
+    """Generate chat-ready content from a list of filenames.
+
+    Args:
+        filenames: Filenames or glob patterns. ``~`` expansion is supported.
 
     Returns:
-        content_parts = list of OpenAI API style `content` messages
-        messages = list of strings of chat messages for each text section.
+        A tuple ``(content_parts, messages)`` where ``content_parts`` contains
+        image parts and ``messages`` contains text messages.
 
     """
-    content_parts = []
-    messages = []
+    content_parts: list[dict[str, object]] = []
+    messages: list[dict[str, str]] = []
     for filename in expand_filename_list(filenames):
         extension = pathlib.Path(filename).suffix[1:]
 
@@ -231,9 +352,16 @@ def get_attachments_content(filenames):
     return content_parts, messages
 
 
-def edit_content_in_editor(content: str, suffix: Optional[str] = None) -> str | None:
-    """Edit the content in an external editor
-    Return the new content or None if unchanged
+def edit_content_in_editor(content: str, suffix: str | None = None) -> str | None:
+    """Edit text in an external editor.
+
+    Args:
+        content: The text to edit.
+        suffix: Optional filename suffix for the temporary file.
+
+    Returns:
+        The modified content, or ``None`` if unchanged.
+
     """
     editor_cmd = lair.config.get("misc.editor_command") or os.getenv("VISUAL") or os.getenv("EDITOR") or "vi"
     editor_args = shlex.split(editor_cmd)
@@ -253,9 +381,17 @@ def edit_content_in_editor(content: str, suffix: Optional[str] = None) -> str | 
             temp_path.unlink()
 
 
-def decode_jsonl(jsonl_str):
-    """Decode JSONL content and return a list of each decoded line"""
-    records = []
+def decode_jsonl(jsonl_str: str) -> list[dict[str, object]]:
+    """Decode JSONL content into a list of records.
+
+    Args:
+        jsonl_str: The JSONL-formatted string.
+
+    Returns:
+        A list of dictionaries parsed from each line.
+
+    """
+    records: list[dict[str, object]] = []
     for line in jsonl_str.split("\n"):
         if line:  # Process only non-blank lines
             records.append(json.loads(line))
@@ -263,12 +399,21 @@ def decode_jsonl(jsonl_str):
     return records
 
 
-def slice_from_str(original_list, slice_str: str):
-    """Apply a slice string (e.g., ':2', '-2:', '1:4:2') to a list and return the new list."""
+def slice_from_str(original_list: list[T], slice_str: str) -> list[T]:
+    """Apply a ``slice`` string to a list.
+
+    Args:
+        original_list: The list to slice.
+        slice_str: Slice notation such as ``":2"`` or ``"1:4:2"``.
+
+    Returns:
+        A new list containing the sliced elements.
+
+    """
     parts = slice_str.split(":")
 
-    def safe_int(value):
-        """Convert to integer if value is not empty, otherwise return None."""
+    def safe_int(value: str) -> int | None:
+        """Convert to integer if ``value`` is not empty."""
         return int(value) if value else None
 
     # Convert parts to integers or None


### PR DESCRIPTION
## Summary
- add module docstring and modern type hints to `util.core`
- document public functions with structured Google-style docstrings
- annotate private helpers and clean up formatting

## Testing
- `python -m compileall -q lair`
- `ruff check lair/util/core.py`
- `ruff format lair/util/core.py`
- `mypy lair/util/core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c681a03408320b3575691a4150d12