### PR TITLE
Fix docstrings & typing in sessions

### DIFF
--- a/lair/sessions/serializer.py
+++ b/lair/sessions/serializer.py
@@ -1,9 +1,26 @@
+"""Helper functions for serializing and persisting chat sessions."""
+
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING, Any
 
 import lair
 
+if TYPE_CHECKING:
+    from .base_chat_session import BaseChatSession
 
-def session_to_dict(chat_session):
+
+def session_to_dict(chat_session: BaseChatSession) -> dict[str, object]:
+    """Convert a chat session into a dictionary representation.
+
+    Args:
+        chat_session: The session instance to serialize.
+
+    Returns:
+        dict[str, object]: The serialized session state.
+
+    """
     return {
         "version": "0.2",
         "settings": lair.config.get_modified_config(),
@@ -20,13 +37,21 @@ def session_to_dict(chat_session):
     }
 
 
-def save(chat_session, filename):
+def save(chat_session: BaseChatSession, filename: str) -> None:
+    """Write a serialized chat session to disk.
+
+    Args:
+        chat_session: The session instance to save.
+        filename: Path to the destination file.
+
+    """
     with open(filename, "w") as state_file:
         state = session_to_dict(chat_session)
         state_file.write(json.dumps(state))
 
 
-def _load__v0_2(chat_session, state):
+def _load__v0_2(chat_session: BaseChatSession, state: dict[str, Any]) -> None:
+    """Load session state from version 0.2 format."""
     lair.config.change_mode(state["session"]["mode"])
     lair.config.update(state["settings"])
     chat_session.last_prompt = state["session"]["last_prompt"]
@@ -37,7 +62,17 @@ def _load__v0_2(chat_session, state):
     chat_session.history.set_history(state["history"])
 
 
-def update_session_from_dict(chat_session, state):
+def update_session_from_dict(chat_session: BaseChatSession, state: dict[str, Any]) -> None:
+    """Update an existing session from a serialized dictionary.
+
+    Args:
+        chat_session: The session instance to update.
+        state: The serialized session state.
+
+    Raises:
+        Exception: If the state version is missing or unsupported.
+
+    """
     if "version" not in state:
         raise Exception("Session state is missing 'version'")
     elif state["version"] == "0.2":
@@ -48,7 +83,14 @@ def update_session_from_dict(chat_session, state):
         raise Exception(f"Session state uses unknown version: {state['version']}")
 
 
-def load(chat_session, filename):
+def load(chat_session: BaseChatSession, filename: str) -> None:
+    """Load a chat session from disk.
+
+    Args:
+        chat_session: The session instance to populate.
+        filename: Path to the file containing serialized state.
+
+    """
     with open(filename) as state_file:
         contents = state_file.read()
         state = json.loads(contents)


### PR DESCRIPTION
## Summary
- document OpenAI chat session module and methods
- validate OpenAI types lazily and improve runtime safety
- document serializer helpers and annotate parameters

## Testing
- `python -m compileall -q lair`
- `ruff check lair` *(fails: Found 1225 errors)*
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c67e3d7a48320b69e23894310d3bd