### PR TITLE
Fix session manager docs and typing

### DIFF
--- a/lair/sessions/session_manager.py
+++ b/lair/sessions/session_manager.py
@@ -1,12 +1,19 @@
+"""Manage chat session metadata in LMDB."""
+
+from __future__ import annotations
+
 import importlib
 import json
 import os
+from collections.abc import Iterator, Sequence
 from typing import Any
 
 import lair
 import lair.sessions.serializer
 import lair.util
 from lair.logging import logger
+
+from .base_chat_session import BaseChatSession
 
 lmdb: Any = importlib.import_module("lmdb")
 
@@ -16,20 +23,24 @@ lmdb: Any = importlib.import_module("lmdb")
 
 
 class UnknownSessionError(Exception):
-    pass
+    """Raised when a session ID or alias cannot be resolved."""
 
 
 UnknownSessionException = UnknownSessionError
 
 
 class SessionManager:
-    def __init__(self):
+    """Provide an interface for storing and retrieving chat sessions."""
+
+    def __init__(self) -> None:
+        """Initialize the manager and ensure the backing store is ready."""
         self.database_path = os.path.expanduser(lair.config.get("database.sessions.path"))
         self.env = lmdb.open(self.database_path, map_size=lair.config.get("database.sessions.size"))
         self.ensure_correct_map_size()
         self.prune_empty()
 
-    def ensure_correct_map_size(self):
+    def ensure_correct_map_size(self) -> None:
+        """Ensure the database map size matches the configured value."""
         configured_size = lair.config.get("database.sessions.size")
         with self.env.begin():
             info = self.env.info()
@@ -39,8 +50,9 @@ class SessionManager:
             with self.env.begin(write=True):
                 self.env.set_mapsize(configured_size)
 
-    def prune_empty(self):
-        session_list = []
+    def prune_empty(self) -> None:
+        """Delete sessions that contain no history."""
+        session_list: list[int] = []
 
         for session in self.all_sessions():
             if len(session["history"]) == 0:
@@ -49,7 +61,8 @@ class SessionManager:
         self.delete_sessions(session_list)
         logger.debug(f"SessionManager(): prune_empty() removed {len(session_list)} empty sessions")
 
-    def _get_next_session_id(self):
+    def _get_next_session_id(self) -> int:
+        """Return the next available numeric session identifier."""
         with self.env.begin() as txn:
             cursor = txn.cursor()
             prefix = b"session:"
@@ -68,7 +81,19 @@ class SessionManager:
 
             return session_id
 
-    def get_session_id(self, id_or_alias, raise_exception=True):
+    def get_session_id(self, id_or_alias: str | int, raise_exception: bool = True) -> int | None:
+        """Resolve a session ID or alias.
+
+        Args:
+            id_or_alias: Numeric ID or alias string to look up.
+            raise_exception: Whether to raise :class:`UnknownSessionError` when the session
+                cannot be resolved.
+
+        Returns:
+            int | None: The resolved session ID, or ``None`` if ``raise_exception`` is ``False`` and
+                the session does not exist.
+
+        """
         with self.env.begin() as txn:
             session_id = txn.get(f"alias:{id_or_alias}".encode())
             if session_id:
@@ -85,7 +110,8 @@ class SessionManager:
         else:
             return None
 
-    def all_sessions(self):
+    def all_sessions(self) -> Iterator[dict[str, Any]]:
+        """Iterate over all stored sessions."""
         with self.env.begin() as txn:
             cursor = txn.cursor()
             prefix = b"session:"
@@ -96,7 +122,8 @@ class SessionManager:
 
                     yield json.loads(value.decode())
 
-    def get_next_session_id(self, session_id):
+    def get_next_session_id(self, session_id: int) -> int | None:
+        """Return the identifier of the session after ``session_id``."""
         sessions = list(self.all_sessions())
         if len(sessions) > 0:
             for i, session in enumerate(sessions):
@@ -107,7 +134,8 @@ class SessionManager:
         else:
             return None  # No sessions found
 
-    def get_previous_session_id(self, session_id):
+    def get_previous_session_id(self, session_id: int) -> int | None:
+        """Return the identifier of the session before ``session_id``."""
         sessions = list(self.all_sessions())
         if len(sessions) > 0:
             for i, session in enumerate(sessions):
@@ -118,7 +146,8 @@ class SessionManager:
         else:
             return None  # No sessions found
 
-    def refresh_from_chat_session(self, chat_session):
+    def refresh_from_chat_session(self, chat_session: BaseChatSession) -> None:
+        """Update a stored session from the given chat session."""
         if not chat_session.session_id:
             self.add_from_chat_session(chat_session)
             return
@@ -143,9 +172,10 @@ class SessionManager:
             if chat_session.session_alias:
                 txn.put(f"alias:{chat_session.session_alias}".encode(), str(session_id).encode())
 
-    def add_from_chat_session(self, chat_session):
+    def add_from_chat_session(self, chat_session: BaseChatSession) -> None:
+        """Persist ``chat_session`` as a new session if needed."""
         if chat_session.session_id is None:
-            chat_session.session_id = self._get_next_session_id()
+            object.__setattr__(chat_session, "session_id", self._get_next_session_id())
 
         session = lair.sessions.serializer.session_to_dict(chat_session)
         with self.env.begin(write=True) as txn:
@@ -153,11 +183,12 @@ class SessionManager:
             if chat_session.session_alias:
                 txn.put(f"alias:{chat_session.session_alias}".encode(), str(chat_session.session_id).encode())
 
-    def delete_session(self, id_or_alias, txn=None):
-        """Delete a session
+    def delete_session(self, id_or_alias: str | int, txn: lmdb.Transaction | None = None) -> None:
+        """Delete a session.
 
-        Arguments:
-          txn: When provided, this lmdb transaction is used instead of creating a new one
+        Args:
+            id_or_alias: The numeric ID or alias of the session to delete.
+            txn: Optional existing LMDB transaction to use.
 
         """
         session_id = self.get_session_id(id_or_alias)
@@ -165,6 +196,9 @@ class SessionManager:
 
         if should_commit:
             txn = self.env.begin(write=True)  # Create a new transaction if none is provided
+
+        if txn is None:
+            raise RuntimeError("Transaction is unexpectedly None")
 
         try:
             session_data = txn.get(f"session:{session_id:08d}".encode())
@@ -184,7 +218,8 @@ class SessionManager:
                 txn.abort()  # Abort if we started the transaction and something went wrong
             raise
 
-    def delete_sessions(self, session_list):
+    def delete_sessions(self, session_list: Sequence[str | int]) -> None:
+        """Delete multiple sessions."""
         with self.env.begin(write=True) as txn:
             if "all" in session_list:
                 for session in self.all_sessions():
@@ -193,7 +228,8 @@ class SessionManager:
                 for session_id in session_list:
                     self.delete_session(session_id, txn=txn)
 
-    def switch_to_session(self, id_or_alias, chat_session):
+    def switch_to_session(self, id_or_alias: str | int, chat_session: BaseChatSession) -> None:
+        """Load session data into ``chat_session``."""
         session_id = self.get_session_id(id_or_alias)
         with self.env.begin() as txn:
             logger.debug(f"SessionManager(): switch_to_session({session_id})")
@@ -201,7 +237,8 @@ class SessionManager:
             session = json.loads(session_data.decode())
             lair.sessions.serializer.update_session_from_dict(chat_session, session)
 
-    def is_alias_available(self, alias):
+    def is_alias_available(self, alias: str) -> bool:
+        """Return ``True`` if ``alias`` is not already in use."""
         if isinstance(lair.util.safe_int(alias), int):
             return False
 
@@ -211,7 +248,10 @@ class SessionManager:
         except UnknownSessionError:
             return True
 
-    def set_alias(self, id_or_alias, new_alias):
+        return False
+
+    def set_alias(self, id_or_alias: str | int, new_alias: str) -> None:
+        """Assign ``new_alias`` to the specified session."""
         if not self.is_alias_available(new_alias):
             raise ValueError("SessionManager(): set_alias(): Alias conflict: Unable to set alias")
 
@@ -229,7 +269,8 @@ class SessionManager:
             txn.put(f"session:{session_id:08d}".encode(), json.dumps(session).encode())
             txn.put(f"alias:{new_alias}".encode(), str(session_id).encode())
 
-    def set_title(self, id_or_alias, new_title):
+    def set_title(self, id_or_alias: str | int, new_title: str) -> None:
+        """Update the title of a session."""
         session_id = self.get_session_id(id_or_alias)
 
         with self.env.begin(write=True) as txn:
@@ -239,7 +280,8 @@ class SessionManager:
             session["title"] = new_title
             txn.put(f"session:{session_id:08d}".encode(), json.dumps(session).encode())
 
-    def get_session_dict(self, id_or_alias):
+    def get_session_dict(self, id_or_alias: str | int) -> dict[str, Any] | None:
+        """Return a stored session as a dictionary."""
         session_id = self.get_session_id(id_or_alias)
         with self.env.begin() as txn:
             session_data = txn.get(f"session:{session_id:08d}".encode())


### PR DESCRIPTION
## Summary
- document session manager module
- annotate and document SessionManager methods
- make type hints compatible with mypy

## Testing
- `python -m compileall -q lair`
- `ruff check lair/sessions/session_manager.py`
- `mypy lair/sessions/session_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c67ef82b48320ab2659b7b2727389