### PR TITLE
Fix reporting module docs and typing

### DIFF
--- a/lair/reporting/__init__.py
+++ b/lair/reporting/__init__.py
@@ -1,3 +1,5 @@
+"""Reporting utilities for the Lair project."""
+
 from .reporting import Reporting
 
 __all__ = ["Reporting"]

--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -1,9 +1,12 @@
+"""Helpers for rendering output in the terminal using rich."""
+
 import datetime
 import math
 import re
 import sys
 import traceback
-from typing import Any
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, cast
 
 import rich
 import rich.columns
@@ -16,9 +19,21 @@ import lair
 
 
 class ReportingSingletoneMeta(type):
+    """Metaclass implementing the singleton pattern for :class:`Reporting`."""
+
     _instances: dict[type, Any] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args: object, **kwargs: object) -> object:
+        """Return a single instance of ``cls``.
+
+        Args:
+            *args: Positional arguments forwarded to ``cls``.
+            **kwargs: Keyword arguments forwarded to ``cls``.
+
+        Returns:
+            object: The existing or newly created instance.
+
+        """
         if cls not in cls._instances:
             instance = super().__call__(*args, **kwargs)
             cls._instances[cls] = instance
@@ -26,7 +41,16 @@ class ReportingSingletoneMeta(type):
 
 
 class Reporting(metaclass=ReportingSingletoneMeta):
-    def __init__(self, *, disable_color=False, force_color=False):
+    """Utility class for formatting and printing messages with rich."""
+
+    def __init__(self, *, disable_color: bool = False, force_color: bool = False) -> None:
+        """Initialize the reporting system.
+
+        Args:
+            disable_color: Disable any color output.
+            force_color: Force rich to output colors even if not in a TTY.
+
+        """
         force_terminal = None
         if disable_color:
             no_color = True
@@ -39,26 +63,62 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         self.console = rich.console.Console(no_color=no_color, force_terminal=force_terminal)
         self.json_highlighter = rich.highlighter.JSONHighlighter()
 
-    def print_rich(self, *args, **kwargs):
-        """Print using rich."""
-        kwargs["no_wrap"] = not lair.config.get("style.word_wrap")
+    def print_rich(self, *args: rich.console.RenderableType, **kwargs: object) -> None:
+        """Print using the internal rich console.
 
-        self.console.print(*args, **kwargs)
+        Args:
+            *args: Objects to print.
+            **kwargs: Options forwarded to ``console.print``.
 
-    def print_highlighted_json(self, json_str):
+        """
+        kw_dict = cast(MutableMapping[str, Any], kwargs)
+        kw_dict["no_wrap"] = not lair.config.get("style.word_wrap")
+        self.console.print(*args, **kw_dict)
+
+    def print_highlighted_json(self, json_str: str) -> None:
+        """Print JSON with optional syntax highlighting.
+
+        Args:
+            json_str: The JSON string to display.
+
+        """
         if lair.config.get("style.messages_command.syntax_highlight"):
             rich.print_json(json_str, indent=None)
         else:
             rich.print(json_str)
 
-    def style(self, *args, **kwargs):
-        """Style a string using rich.
-        If no style parameter is provided, convert to plaintext so that rich markup isn't processed
-        """
-        return rich.text.Text(*args, **kwargs)
+    def style(self, *args: object, **kwargs: Mapping[str, object]) -> rich.text.Text:
+        """Create a :class:`rich.text.Text` instance.
 
-    def filter_keys_dict_list(self, rows_of_dicts, allowed_keys):
-        new_rows = []
+        If no ``style`` parameter is provided the text is converted to plain
+        text so that rich markup is not processed.
+
+        Args:
+            *args: Positional arguments forwarded to ``Text``.
+            **kwargs: Keyword arguments forwarded to ``Text``.
+
+        Returns:
+            ``Text``: The styled text object.
+
+        """
+        return rich.text.Text(*cast(Sequence[str], args), **cast(dict[str, Any], kwargs))
+
+    def filter_keys_dict_list(
+        self,
+        rows_of_dicts: Sequence[Mapping[str, Any]] | None,
+        allowed_keys: Iterable[str],
+    ) -> list[dict[str, Any]]:
+        """Filter dictionaries to only include specified keys.
+
+        Args:
+            rows_of_dicts: Iterable of dictionaries to filter.
+            allowed_keys: Keys that should be retained.
+
+        Returns:
+            A list of dictionaries containing only ``allowed_keys``.
+
+        """
+        new_rows: list[dict[str, Any]] = []
         for row in rows_of_dicts or []:
             new_rows.append(dict(filter(lambda r: r[0] in allowed_keys, row.items())))
 
@@ -66,21 +126,39 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
     def table_from_dicts(
         self,
-        rows_of_dicts,
+        rows_of_dicts: Sequence[Mapping[str, Any]] | None,
         *,
-        column_names=None,
-        column_formatters=None,
-        automatic_column_names=True,
-        style=None,
-        markup=False,
-    ):
+        column_names: Sequence[str] | None = None,
+        column_formatters: Mapping[str, Callable[[object], object]] | None = None,
+        automatic_column_names: bool = True,
+        style: str | None = None,
+        markup: bool = False,
+    ) -> None:
+        """Render a table from a sequence of dictionaries.
+
+        Args:
+            rows_of_dicts: Data to render.
+            column_names: Column names to display. If ``None`` and
+                ``automatic_column_names`` is ``True``, names are taken from the
+                first row.
+            column_formatters: Optional mapping of column names to formatter
+                callables.
+            automatic_column_names: Determine column names from the first row
+                when ``column_names`` is ``None``.
+            style: Base table style.
+            markup: When ``True`` values are treated as rich markup.
+
+        """
         if not rows_of_dicts:
             return
 
         if column_names is None:
-            column_names = list(rows_of_dicts[0].keys()) if automatic_column_names else None
+            column_names = list(rows_of_dicts[0].keys()) if automatic_column_names else []
         else:
             column_names = list(column_names)
+
+        if not column_names:
+            return
 
         # Construct table rows by selecting values based on the specified column order.
         # This ensures only the requested columns are included and maintains their order.
@@ -90,17 +168,25 @@ class Reporting(metaclass=ReportingSingletoneMeta):
             table_rows, column_names=column_names, column_formatters=column_formatters, style=style, markup=markup
         )
 
-    def format_value(self, value):
+    def format_value(self, value: object) -> str:
+        """Convert a value to a printable string."""
         if value is None:
             return ""
-        elif isinstance(value, datetime.datetime):
+        if isinstance(value, datetime.datetime):
             return value.strftime("%m/%d/%y %H:%M:%S")
-        elif not isinstance(value, str):
+        if not isinstance(value, str):
             return str(value)
-        else:
-            return value
+        return value
 
-    def table(self, rows, *, column_names=None, column_formatters=None, style=None, markup=False):
+    def table(
+        self,
+        rows: Iterable[Iterable[object]] | None,
+        *,
+        column_names: Sequence[str] | None = None,
+        column_formatters: Mapping[str, Callable[[object], object]] | None = None,
+        style: str | None = None,
+        markup: bool = False,
+    ) -> None:
         """Display a table from a 2-dimensional array.
 
         Args:
@@ -126,7 +212,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         if rows is None:
             return
 
-        table = rich.table.Table(style=style, show_header=column_names is not None)
+        table = rich.table.Table(style=style or "none", show_header=column_names is not None)
 
         if column_names:
             for column_name in column_names:
@@ -136,11 +222,18 @@ class Reporting(metaclass=ReportingSingletoneMeta):
             formatted = [
                 self._format_cell(cell, idx, column_names, column_formatters, markup) for idx, cell in enumerate(row)
             ]
-            table.add_row(*formatted)
+            table.add_row(*cast(list[rich.console.RenderableType], formatted))
 
         self.print_rich(table)
 
-    def _format_cell(self, cell, idx, column_names, column_formatters, markup):
+    def _format_cell(
+        self,
+        cell: object,
+        idx: int,
+        column_names: Sequence[str] | None,
+        column_formatters: Mapping[str, Callable[[object], object]] | None,
+        markup: bool,
+    ) -> object:
         if column_names and column_formatters and idx < len(column_names) and column_names[idx] in column_formatters:
             return column_formatters[column_names[idx]](cell)
 
@@ -149,36 +242,60 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
         return cell
 
-    def table_from_dicts_system(self, *args, **kwargs):
+    def table_from_dicts_system(self, *args: Sequence[Mapping[str, Any]], **kwargs: object) -> None:
+        """Proxy to :meth:`table_from_dicts` using system message styling."""
         kwargs["style"] = lair.config.get("style.system_message")
-        self.table_from_dicts(*args, **kwargs)
+        self.table_from_dicts(*args, **cast(dict[str, Any], kwargs))
 
-    def table_system(self, *args, **kwargs):
+    def table_system(self, *args: Iterable[Iterable[object]], **kwargs: object) -> None:
+        """Proxy to :meth:`table` using system message styling."""
         kwargs["style"] = lair.config.get("style.system_message")
-        self.table(*args, **kwargs)
+        self.table(*args, **cast(dict[str, Any], kwargs))
 
-    def exception(self):
+    def exception(self) -> None:
+        """Print the current exception using configured styling."""
         if lair.config.get("style.render_rich_tracebacks"):
             self.print_rich(rich.traceback.Traceback())
         else:
             traceback.print_exception(*sys.exc_info())
 
-    def error(self, message, show_exception=None):
-        """When show_exception is:
-        - None - Show if DEBUG is enabled
-        - true - Always show
-        - false - Never show
+    def error(self, message: str, show_exception: bool | None = None) -> None:
+        """Print an error message and optionally the current exception.
+
+        Args:
+            message: The error text to display.
+            show_exception: ``True`` to always show the traceback, ``False`` to
+                never show it, or ``None`` to show only when debug is enabled.
+
         """
         if show_exception or show_exception is None and lair.util.is_debug_enabled():
             self.exception()
 
         self.print_rich(self.style("ERROR: " + message), style=lair.config.get("style.error"))
 
-    def format_json(self, json_str, max_length=None, plain_style=None, enable_highlighting=True):
+    def format_json(
+        self,
+        json_str: str,
+        max_length: int | None = None,
+        plain_style: str | None = None,
+        enable_highlighting: bool = True,
+    ) -> rich.text.Text:
+        """Format a JSON string for console output.
+
+        Args:
+            json_str: The JSON content to format.
+            max_length: Truncate output to this length if provided.
+            plain_style: Rich style to apply when highlighting is disabled.
+            enable_highlighting: Whether to apply JSON syntax highlighting.
+
+        Returns:
+            ``Text``: The formatted JSON text.
+
+        """
         if enable_highlighting:
             json_text = self.json_highlighter(json_str)
         else:
-            json_text = rich.text.Text(json_str, style=plain_style)
+            json_text = rich.text.Text(json_str, style=plain_style or "")
 
         if max_length is not None and len(json_text) > max_length:
             json_text = json_text[:max_length]
@@ -186,7 +303,8 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
         return json_text
 
-    def assistant_tool_calls(self, message, show_heading=False):
+    def assistant_tool_calls(self, message: Mapping[str, Any], show_heading: bool = False) -> None:
+        """Display assistant tool calls contained in a message."""
         if lair.config.get("style.llm_output.tool_call.background"):
             background_style = " on " + lair.config.get("style.llm_output.tool_call.background")
         else:
@@ -221,7 +339,8 @@ class Reporting(metaclass=ReportingSingletoneMeta):
             remaining_characters = self.console.width - len(text) % self.console.width
             self.console.print(" " * remaining_characters, style=background_style)
 
-    def tool_message(self, message, show_heading=False):
+    def tool_message(self, message: Mapping[str, Any], show_heading: bool = False) -> None:
+        """Display a tool response message."""
         if lair.config.get("style.tool_message.background"):
             background_style = " on " + lair.config.get("style.tool_message.background")
         else:
@@ -251,10 +370,17 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         remaining_characters = self.console.width - len(text) % self.console.width
         self.console.print(" " * remaining_characters, style=background_style)
 
-    def user_error(self, message):
+    def user_error(self, message: str) -> None:
+        """Display a user-facing error message."""
         self.print_rich(self.style(message), style=lair.config.get("style.user_error"))
 
-    def system_message(self, message, show_heading=False, disable_markdown=False):
+    def system_message(
+        self,
+        message: str,
+        show_heading: bool = False,
+        disable_markdown: bool = False,
+    ) -> None:
+        """Display a system message."""
         if show_heading:
             self.print_rich("SYSTEM", style=lair.config.get("style.system_message_heading"))
 
@@ -263,7 +389,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         else:
             self.print_rich(self.style(message), style=lair.config.get("style.system_message"))
 
-    def _llm_output__with_thoughts(self, message):
+    def _llm_output__with_thoughts(self, message: str) -> None:
         sections = re.split(r"(<(?:thought|think|thinking)>.*?</(?:thought|think|thinking)>)", message, flags=re.DOTALL)
         pattern = re.compile(r"<(thought|think|thinking)>.*?</\1>", re.DOTALL)
 
@@ -279,7 +405,8 @@ class Reporting(metaclass=ReportingSingletoneMeta):
             elif section.strip():  # Ignore completely empty sections
                 self.print_rich(rich.markdown.Markdown(section), style=lair.config.get("style.llm_output"))
 
-    def llm_output(self, message, show_heading=False):
+    def llm_output(self, message: str, show_heading: bool = False) -> None:
+        """Render large language model output."""
         if show_heading:
             self.print_rich("AI", style=lair.config.get("style.llm_output_heading"))
 
@@ -291,20 +418,22 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         else:
             self.print_rich(self.style(message), style=lair.config.get("style.llm_output"))
 
-    def format_content_list(self, content_list):
+    def format_content_list(self, content_list: Iterable[Mapping[str, Any]]) -> str:
+        """Format a content list from the OpenAI API for display."""
         message_parts = ["[multipart message]"]
         for part in content_list:
             if part["type"] == "text":
                 message_parts.append(f"---> text: {part['text']}")
             elif part["type"] == "image_url":
-                mime_type = re.match(r"data:([^;]+);base64,", part["image_url"]["url"]).group(1)
+                match = re.match(r"data:([^;]+);base64,", part["image_url"]["url"])
+                mime_type = match.group(1) if match else "unknown"
                 message_parts.append(f"---> image: {mime_type}")
             else:
                 raise ValueError("format_content_list(): Unknown content type: {part['type']}")
 
         return "\n".join(message_parts)
 
-    def message(self, message):
+    def message(self, message: Mapping[str, Any]) -> None:
         """Display a message object in history style."""
         if isinstance(message["content"], str):
             content = message["content"].rstrip()
@@ -326,8 +455,9 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         else:
             self.system_message(content, show_heading=True)
 
-    def messages_to_str(self, messages):
-        lines = []
+    def messages_to_str(self, messages: Iterable[Mapping[str, Any]]) -> str:
+        """Convert a list of message dicts to a human-readable string."""
+        lines: list[str] = []
         for message in messages:
             lines.append(f"{message['role'].upper()}: {message['content']}")
 
@@ -335,16 +465,16 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
     def get_style_by_range(
         self,
-        value,
-        minimum=0,
-        maximum=100,
+        value: float,
+        minimum: float = 0,
+        maximum: float = 100,
         *,
-        display_value=None,
-        log=False,
-        inverse=False,
-        styles=None,
-    ):
-        """Color a value based on where it falls within a range"""
+        display_value: float | None = None,
+        log: bool = False,
+        inverse: bool = False,
+        styles: Sequence[str] | None = None,
+    ) -> str:
+        """Color a value based on where it falls within a range."""
         if styles is None:
             styles = [
                 "rgb(51,0,0)",
@@ -371,7 +501,16 @@ class Reporting(metaclass=ReportingSingletoneMeta):
 
         return styles[round(len(styles) * index_percent)]
 
-    def color_gt_lt(self, value, *, center=0, gt_style="green", lt_style="red", eq_style="gray"):
+    def color_gt_lt(
+        self,
+        value: float,
+        *,
+        center: float = 0,
+        gt_style: str = "green",
+        lt_style: str = "red",
+        eq_style: str = "gray",
+    ) -> str:
+        """Return a style based on a comparison to ``center``."""
         if value > center:
             return gt_style
         elif value < center:
@@ -379,7 +518,15 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         else:
             return eq_style
 
-    def color_bool(self, value, true_str="true", false_str="false", true_style="bold green", false_style="dim red"):
+    def color_bool(
+        self,
+        value: bool,
+        true_str: str = "true",
+        false_str: str = "false",
+        true_style: str = "bold green",
+        false_style: str = "dim red",
+    ) -> rich.text.Text:
+        """Return ``true_str`` or ``false_str`` styled appropriately."""
         if value:
             return rich.text.Text(true_str, style=true_style)
         else:

--- a/lair/sessions/base_chat_session.py
+++ b/lair/sessions/base_chat_session.py
@@ -20,8 +20,8 @@ class BaseChatSession(abc.ABC):
 
         """
         self.reporting = lair.reporting.Reporting()
-        self.last_prompt = None
-        self.last_response = None
+        self.last_prompt: str | None = None
+        self.last_response: str | None = None
 
         self.session_id = None  # Id for session management, provided by SessionManager()
         self.session_alias = None  # Alias string for session management purposes


### PR DESCRIPTION
## Summary
- document reporting package
- overhaul `Reporting` docstrings and type hints
- refine singleton metaclass and helper methods
- type annotate chat session base attributes

## Testing
- `poetry run ruff check lair/reporting/__init__.py lair/reporting/reporting.py`
- `poetry run ruff format lair/reporting/__init__.py lair/reporting/reporting.py`
- `poetry run python -m compileall -q lair`
- `poetry run mypy lair`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c67c07e7c8320b5507feb19dc6883