### PR TITLE
Fix image path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - cli: Reduce complexity of keybindings setup
 - tests: Increase coverage for chat interface reports
 - comfyscript: Restart watch thread correctly
+- comfy: Raise ValueError for invalid image path type
 - tests: Support environments where `openai_local` mode is renamed
 
 ### New Features

--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -193,6 +193,9 @@ class ComfyCaller:
 
     def _image_to_base64(self, image: str) -> str:
         """Return the base64 representation of an image file."""
+        if not isinstance(image, str):
+            raise ValueError("image must be a string path")
+
         with open(image, "rb") as image_file:
             return base64.b64encode(image_file.read()).decode("utf-8")
 


### PR DESCRIPTION
## Summary
- raise an error if image path is not a string
- document fix

## Testing
- `python -m compileall -q lair/comfy_caller.py`
- `ruff check lair | head -n 5`
- `mypy lair > /tmp/mypy.log && head -n 5 /tmp/mypy.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6d6a00488320ba18fc9187133878