### PR TITLE
Improve docstrings and typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - internal: update code for new ruff version
 - tests: Enforce 90% minimum test coverage and add many new tests.
 - docker: Add lair into youtube image
+- internal: add docstrings and type annotations for history utilities
 - documentation: Expand README outpainting example
 - tools: improve docstrings and type hints for ToolSet
 - cleanup: refactor workflow and tool call helpers for readability

--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 import traceback
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import lair.logging
 import lair.module_loader
@@ -12,7 +12,7 @@ import lair.util
 from lair.logging import logger
 
 
-def init_subcommands(parent_parser: argparse.ArgumentParser) -> Dict[str, Any]:
+def init_subcommands(parent_parser: argparse.ArgumentParser) -> dict[str, Any]:
     """Initialize all CLI subcommands.
 
     Args:
@@ -42,7 +42,7 @@ def init_subcommands(parent_parser: argparse.ArgumentParser) -> Dict[str, Any]:
     return commands
 
 
-def parse_arguments() -> Tuple[argparse.Namespace, Any]:
+def parse_arguments() -> tuple[argparse.Namespace, Any]:
     """Parse command line arguments.
 
     Returns:
@@ -83,7 +83,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, Any]:
     return arguments, subcommands[arguments.subcommand]
 
 
-def set_config_from_arguments(overrides: List[str] | None) -> None:
+def set_config_from_arguments(overrides: list[str] | None) -> None:
     """Apply ``--set`` command line overrides to the active configuration.
 
     Args:

--- a/lair/components/__init__.py
+++ b/lair/components/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable components used throughout the Lair application."""

--- a/lair/components/history/__init__.py
+++ b/lair/components/history/__init__.py
@@ -1,3 +1,5 @@
+"""Chat history management utilities."""
+
 from .chat_history import ChatHistory
 
 __all__ = ["ChatHistory"]

--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -1,5 +1,11 @@
+"""Utility classes for managing and validating chat history."""
+
+from __future__ import annotations
+
 import copy
 import json
+from collections.abc import Iterable
+from typing import Any
 
 import lair
 import lair.components.history.schema
@@ -7,42 +13,57 @@ from lair.logging import logger
 
 
 class ChatHistory:
+    """Container for chat messages with optional rollback support."""
+
     ALLOWED_ROLES = {"assistant", "system", "tool", "user"}
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize a new ``ChatHistory`` instance."""
         # This is the full non-truncated history. Truncation only occurs after commit().
-        self._history = []
+        self._history: list[dict[str, Any]] = []
 
         # In the event that a chat attempt fails, the history needs to rollback.
         # To make this possible, the session chat() function calls commit()
         # which updates the finalized_index. In the event of a failure, a call
         # to rollback() is made, which truncates history beyond the finalized
         # index.
-        self.finalized_index = None
+        self.finalized_index: int | None = None
 
         lair.events.subscribe("config.update", lambda d: self._validate_config(), instance=self)
 
         self._validate_config()
 
-    def __copy__(self):
+    def __copy__(self) -> ChatHistory:
+        """Return a shallow copy of this history."""
         new_chat_history = ChatHistory()
         new_chat_history._history = copy.copy(self._history)
         new_chat_history.finalized_index = self.finalized_index
         return new_chat_history
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict[int, Any]) -> ChatHistory:
+        """Return a deep copy of this history."""
         new_chat_history = ChatHistory()
         new_chat_history._history = copy.deepcopy(self._history, memo)
         new_chat_history.finalized_index = self.finalized_index
         return new_chat_history
 
-    def _validate_config(self):
+    def _validate_config(self) -> None:
+        """Ensure ``session.max_history_length`` is valid."""
         max_length = lair.config.get("session.max_history_length")
         if max_length == 0:
             logger.warning("Invalid value for session.max_history_length. Must be greater than 0. Setting to null.")
             lair.config.active["session.max_history_length"] = None
 
-    def add_tool_messages(self, messages):
+    def add_tool_messages(self, messages: Iterable[dict[str, Any]]) -> None:
+        """Append assistant or tool messages to the history.
+
+        Args:
+            messages: Sequence of messages from the API to add.
+
+        Raises:
+            ValueError: If a message role is not ``tool`` or ``assistant``.
+
+        """
         for message in messages:
             if message["role"] == "tool":
                 self._history.append(
@@ -67,7 +88,18 @@ class ChatHistory:
                     "a role that wasn't 'tool' or 'assistant'"
                 )
 
-    def add_message(self, role, message, *, meta=None):
+    def add_message(self, role: str, message: object, *, meta: dict[str, object] | None = None) -> None:
+        """Append a single message to the history.
+
+        Args:
+            role: The role of the message sender.
+            message: The message content.
+            meta: Optional additional metadata to store.
+
+        Raises:
+            ValueError: If ``role`` is invalid.
+
+        """
         if role == "tool":
             raise ValueError("add_message(): Role of tool is invalid. Use add_tool_message()")
         elif role not in self.ALLOWED_ROLES:
@@ -80,15 +112,17 @@ class ChatHistory:
             }
         )
 
-    def add_messages(self, messages):
+    def add_messages(self, messages: Iterable[dict[str, Any]]) -> None:
+        """Append multiple messages to the history."""
         for message in messages:
-            self.add_message(message["role"], message["content"])
+            self.add_message(message["role"], message.get("content"))
 
-    def num_messages(self):
+    def num_messages(self) -> int:
+        """Return the number of stored messages."""
         return len(self._history)
 
-    def get_messages(self, *, extra_messages=None):
-        """Return the message history, truncating as necessary"""
+    def get_messages(self, *, extra_messages: Iterable[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+        """Return the message history, truncating as necessary."""
         max_length = lair.config.get("session.max_history_length") or 0
 
         if extra_messages is None:
@@ -96,25 +130,26 @@ class ChatHistory:
         else:
             return self._history[-max_length:] + extra_messages
 
-    def get_messages_as_jsonl_string(self):
+    def get_messages_as_jsonl_string(self) -> str:
+        """Return the history encoded as a JSON Lines string."""
         messages = self.get_messages()
         return "\n".join(json.dumps(message) for message in messages)
 
-    def set_history(self, messages):
-        """Replace history with the provided messages"""
+    def set_history(self, messages: list[dict[str, Any]]) -> None:
+        """Replace history with the provided messages."""
         lair.components.history.schema.validate_messages(messages)
 
         self._history = messages
         self._truncate()
         self.finalized_index = len(self._history)
 
-    def clear(self):
-        """Clear the history"""
+    def clear(self) -> None:
+        """Clear the stored history."""
         self._history = []
         self.finalized_index = None
 
-    def _truncate(self):
-        """If max_history_length is set, trim the history"""
+    def _truncate(self) -> None:
+        """Trim the history if ``session.max_history_length`` is set."""
         # This should only be called by commit() or set_history()
         # The history normally is not stored truncated otherwise so that
         # it is possible to rollback to the previous state.
@@ -122,13 +157,13 @@ class ChatHistory:
         if max_length is not None:
             self._history = self._history[-max_length:]
 
-    def commit(self):
-        """Mark the current history as being finalized"""
+    def commit(self) -> None:
+        """Mark the current history as being finalized."""
         self.finalized_index = len(self._history)
         logger.debug(f"Committing history (finalized_index={self.finalized_index})")
 
-    def rollback(self):
-        """Remove any non-finalized items in the history, such as after a chat attempt fails"""
+    def rollback(self) -> None:
+        """Remove non-finalized items, typically after a chat attempt fails."""
         if self.finalized_index is None:
             logger.debug(f"Rolling back history (finalized_index=null, removing={len(self._history)})")
             self.clear()


### PR DESCRIPTION
## Summary
- document components package and history utilities
- add type hints and structured docstrings for ChatHistory
- use builtin generics in CLI runner
- update changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair` *(fails: Found 138 errors in 18 files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c717c961483209a91a2242c8e2d24