### PR TITLE
Fix ruff warnings

### DIFF
--- a/lair/comfy_caller.py
+++ b/lair/comfy_caller.py
@@ -110,7 +110,7 @@ class ComfyCaller:
             kwargs["ssl"] = ssl_context
             return original_init(self, *args, **kwargs)
 
-        setattr(aiohttp.TCPConnector, "__init__", cast(Any, patched_init))
+        aiohttp.TCPConnector.__init__ = cast(Any, patched_init)
 
     def _import_comfy_script(self) -> None:
         """Import ``comfy_script`` and load node definitions."""
@@ -272,10 +272,7 @@ class ComfyCaller:
     def _get_defaults_image(self) -> dict[str, Any]:
         """Return default parameters for the ``image`` workflow."""
         loras_val = lair.config.get("comfy.image.loras")
-        if loras_val is not None:
-            loras = [lora for lora in str(loras_val).split("\n") if lora]
-        else:
-            loras = None
+        loras = [lora for lora in str(loras_val).split("\n") if lora] if loras_val is not None else None
 
         return {
             "batch_size": lair.config.get("comfy.image.batch_size"),
@@ -527,10 +524,7 @@ class ComfyCaller:
     def _get_defaults_hunyuan_video_t2v(self) -> dict[str, Any]:
         """Return default parameters for the hunyuan-video-t2v workflow."""
         loras_val = lair.config.get("comfy.hunyuan_video.loras")
-        if loras_val is not None:
-            loras = [lora for lora in str(loras_val).split("\n") if lora]
-        else:
-            loras = None
+        loras = [lora for lora in str(loras_val).split("\n") if lora] if loras_val is not None else None
 
         return {
             "batch_size": lair.config.get("comfy.hunyuan_video.batch_size"),
@@ -624,10 +618,7 @@ class ComfyCaller:
     def _get_defaults_outpaint(self) -> dict[str, Any]:
         """Return default parameters for the ``outpaint`` workflow."""
         loras_val = lair.config.get("comfy.outpaint.loras")
-        if loras_val is not None:
-            loras = [lora for lora in str(loras_val).split("\n") if lora]
-        else:
-            loras = None
+        loras = [lora for lora in str(loras_val).split("\n") if lora] if loras_val is not None else None
 
         return {
             "cfg": lair.config.get("comfy.outpaint.cfg"),

--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -306,10 +306,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
     def assistant_tool_calls(self, message: Mapping[str, Any], show_heading: bool = False) -> None:
         """Display assistant tool calls contained in a message."""
         background_val = lair.config.get("style.llm_output.tool_call.background")
-        if background_val:
-            background_style = " on " + str(background_val)
-        else:
-            background_style = ""
+        background_style = " on " + str(background_val) if background_val else ""
 
         if show_heading:
             self.print_rich(
@@ -343,10 +340,7 @@ class Reporting(metaclass=ReportingSingletoneMeta):
     def tool_message(self, message: Mapping[str, Any], show_heading: bool = False) -> None:
         """Display a tool response message."""
         background_val = lair.config.get("style.tool_message.background")
-        if background_val:
-            background_style = " on " + str(background_val)
-        else:
-            background_style = ""
+        background_style = " on " + str(background_val) if background_val else ""
 
         if show_heading:
             self.console.print(


### PR DESCRIPTION
## Summary
- clean up comfy caller style
- simplify reporting background style

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair` *(fails: 92 errors in 13 files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c76c30df08320a139f7fa1e01f6de