### PR TITLE
Fix mypy issues in search and python tools

### DIFF
--- a/lair/components/tools/python_tool.py
+++ b/lair/components/tools/python_tool.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import traceback
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import lair
 from lair.components.tools.tool_set import ToolSet
@@ -147,7 +147,7 @@ class PythonTool:
                     "-d",
                     "-v",
                     f"{shlex.quote(temp_file_path)}:{shlex.quote(container_script_path)}:ro",
-                    shlex.quote(lair.config.get("tools.python.docker_image")),
+                    shlex.quote(cast(str, lair.config.get("tools.python.docker_image"))),
                     "python",
                     shlex.quote(container_script_path),
                 ],
@@ -164,7 +164,7 @@ class PythonTool:
                     [shlex.quote(self._docker), "wait", shlex.quote(container_id)],
                     capture_output=True,
                     text=True,
-                    timeout=lair.config.get("tools.python.timeout"),
+                    timeout=cast(float, lair.config.get("tools.python.timeout")),
                 )
             except subprocess.TimeoutExpired:
                 self._cleanup_container(container_id)

--- a/lair/components/tools/search_tool.py
+++ b/lair/components/tools/search_tool.py
@@ -1,6 +1,6 @@
 """Tools for performing DuckDuckGo web and news searches."""
 
-from typing import Any
+from typing import Any, cast
 
 import requests
 import trafilatura
@@ -83,10 +83,11 @@ class SearchTool:
             or an empty string if extraction fails.
 
         """
-        max_length = lair.config.get("tools.search.max_length")
+        max_length = cast(int, lair.config.get("tools.search.max_length"))
 
         try:
-            response = requests.get(url, timeout=lair.config.get("tools.search.timeout"))
+            timeout = cast(float, lair.config.get("tools.search.timeout"))
+            response = requests.get(url, timeout=timeout)
             response.raise_for_status()
 
             text_content = trafilatura.extract(response.text, include_comments=False, include_tables=False)
@@ -112,7 +113,7 @@ class SearchTool:
             failure.
 
         """
-        max_results = lair.config.get("tools.search.max_results")
+        max_results = cast(int, lair.config.get("tools.search.max_results"))
 
         try:
             results = self.ddgs.text(query, max_results=max_results * 4)
@@ -143,7 +144,7 @@ class SearchTool:
             failure.
 
         """
-        max_results = lair.config.get("tools.search.max_results")
+        max_results = cast(int, lair.config.get("tools.search.max_results"))
 
         try:
             results = self.ddgs.news(query, max_results=max_results * 4)


### PR DESCRIPTION
## Summary
- fix mypy type errors in search_tool
- fix mypy type errors in python_tool

## Testing
- `python -m compileall -q lair`
- `ruff format lair`
- `mypy lair/components/tools/search_tool.py lair/components/tools/python_tool.py`
- `pytest`
- `ruff check lair` *(fails: Found 6 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687c777984688320a072ee1c68fbbdc4