### PR TITLE
Fix mypy issues

### DIFF
--- a/lair/components/history/chat_history.py
+++ b/lair/components/history/chat_history.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 import lair
 import lair.components.history.schema
@@ -123,12 +123,13 @@ class ChatHistory:
 
     def get_messages(self, *, extra_messages: Iterable[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
         """Return the message history, truncating as necessary."""
-        max_length = lair.config.get("session.max_history_length") or 0
+        max_length_obj = lair.config.get("session.max_history_length") or 0
+        max_length = cast(int, max_length_obj)
 
         if extra_messages is None:
             return self._history[-max_length:]
         else:
-            return self._history[-max_length:] + extra_messages
+            return self._history[-max_length:] + list(extra_messages)
 
     def get_messages_as_jsonl_string(self) -> str:
         """Return the history encoded as a JSON Lines string."""
@@ -153,9 +154,9 @@ class ChatHistory:
         # This should only be called by commit() or set_history()
         # The history normally is not stored truncated otherwise so that
         # it is possible to rollback to the previous state.
-        max_length = lair.config.get("session.max_history_length")
-        if max_length is not None:
-            self._history = self._history[-max_length:]
+        max_length_obj = lair.config.get("session.max_history_length")
+        if max_length_obj is not None:
+            self._history = self._history[-cast(int, max_length_obj) :]
 
     def commit(self) -> None:
         """Mark the current history as being finalized."""

--- a/lair/sessions/base_chat_session.py
+++ b/lair/sessions/base_chat_session.py
@@ -2,7 +2,7 @@
 
 import abc
 import copy
-from typing import Any
+from typing import Any, cast
 
 import lair
 import lair.reporting
@@ -115,11 +115,11 @@ class BaseChatSession(abc.ABC):
 
         user_message = None
         assistant_reply = None
-        for message in self.history.get_messages():
-            if not user_message and message["role"] == "user" and message["content"]:
-                user_message = message["content"]
-            elif not assistant_reply and message["role"] == "assistant" and message["content"]:
-                assistant_reply = message["content"]
+        for history_message in self.history.get_messages():
+            if not user_message and history_message["role"] == "user" and history_message["content"]:
+                user_message = history_message["content"]
+            elif not assistant_reply and history_message["role"] == "assistant" and history_message["content"]:
+                assistant_reply = history_message["content"]
 
             if user_message and assistant_reply:
                 break
@@ -133,12 +133,14 @@ class BaseChatSession(abc.ABC):
 
         message = self.invoke(
             disable_system_prompt=True,
-            model=lair.config.get("session.auto_generate_titles.model"),
-            temperature=lair.config.get("session.auto_generate_titles.temperature"),
+            model=cast(str | None, lair.config.get("session.auto_generate_titles.model")),
+            temperature=cast(float | None, lair.config.get("session.auto_generate_titles.temperature")),
             messages=[
                 {
                     "role": "system",
-                    "content": lair.util.prompt_template.fill(lair.config.get("session.auto_generate_titles.template")),
+                    "content": lair.util.prompt_template.fill(
+                        cast(str, lair.config.get("session.auto_generate_titles.template"))
+                    ),
                 },
                 {
                     "role": "user",
@@ -153,7 +155,7 @@ class BaseChatSession(abc.ABC):
 
     def get_system_prompt(self) -> str:
         """Return the filled system prompt template."""
-        return lair.util.prompt_template.fill(lair.config.get("session.system_prompt_template"))
+        return lair.util.prompt_template.fill(cast(str, lair.config.get("session.system_prompt_template")))
 
     def save_to_file(self, filename: str) -> None:
         """Persist the session state to ``filename``."""

--- a/lair/sessions/session_manager.py
+++ b/lair/sessions/session_manager.py
@@ -6,7 +6,7 @@ import importlib
 import json
 import os
 from collections.abc import Iterator, Sequence
-from typing import Any
+from typing import Any, cast
 
 import lair
 import lair.sessions.serializer
@@ -34,8 +34,12 @@ class SessionManager:
 
     def __init__(self) -> None:
         """Initialize the manager and ensure the backing store is ready."""
-        self.database_path = os.path.expanduser(lair.config.get("database.sessions.path"))
-        self.env = lmdb.open(self.database_path, map_size=lair.config.get("database.sessions.size"))
+        path = cast(str, lair.config.get("database.sessions.path"))
+        self.database_path = os.path.expanduser(path)
+        self.env = lmdb.open(
+            self.database_path,
+            map_size=cast(int, lair.config.get("database.sessions.size")),
+        )
         self.ensure_correct_map_size()
         self.prune_empty()
 


### PR DESCRIPTION
## Summary
- ensure chat history uses proper int casts
- update base chat session to use explicit casts
- handle optional overrides in `OpenAIChatSession.invoke`
- add type casts for session manager paths

## Testing
- `ruff check lair/components/history/chat_history.py lair/sessions/base_chat_session.py lair/sessions/openai_chat_session.py lair/sessions/session_manager.py`
- `ruff format lair/components/history/chat_history.py lair/sessions/base_chat_session.py lair/sessions/openai_chat_session.py lair/sessions/session_manager.py`
- `mypy lair/components/history/chat_history.py lair/sessions/base_chat_session.py lair/sessions/openai_chat_session.py lair/sessions/session_manager.py`
- `python -m compileall -q lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c77c375c48320a3859900d3715fbd