### PR TITLE
Fix chat help circular import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # WIP - v0.8.2+dev
 
 ### Bug Fixes
+- cli: Resolve circular import preventing `lair chat --help`
 - comfy: Fix `ltxv-i2v` default model version
 - util: Fix issue where image attachments stopped working
 - cli: Reduce complexity of keybindings setup

--- a/lair/cli/chat_interface_completer.py
+++ b/lair/cli/chat_interface_completer.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.document import Document
 
 import lair
 
-from .chat_interface import ChatInterface
+if TYPE_CHECKING:
+    from .chat_interface import ChatInterface
 
 
 class ChatInterfaceCompleter(Completer):

--- a/tests/integration/test_cli_help.py
+++ b/tests/integration/test_cli_help.py
@@ -11,12 +11,10 @@ import pytest
 STUB_SCRIPT = """
 import sys, types
 for name in [
-    'lair.cli.chat_interface', 'openai', 'requests', 'trafilatura', 'PIL',
+    'openai', 'requests', 'trafilatura', 'PIL',
     'diffusers', 'transformers', 'torch', 'comfy_script', 'lair.comfy_caller'
 ]:
     mod = types.ModuleType(name)
-    if name == 'lair.cli.chat_interface':
-        mod.ChatInterface = object
     sys.modules[name] = mod
 import lair.cli.run as run
 class Dummy:


### PR DESCRIPTION
## Summary
- fix circular import by making ChatInterface type import optional
- tighten integration test to catch circular import
- document fix in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceaa842288320a5c99a8ef24b1c25