### PR TITLE
Fix test warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - tests: Increase coverage for chat interface reports
 - comfyscript: Restart watch thread correctly
 - comfy: Raise ValueError for invalid image path type
+- tests: Stub prompt_toolkit run_in_terminal to remove warnings
 - tests: Support environments where `openai_local` mode is renamed
 
 ### New Features

--- a/lair/util/core.py
+++ b/lair/util/core.py
@@ -154,8 +154,7 @@ def read_package_file(path: str, name: str) -> str:
         The file contents as a string.
 
     """
-    with importlib.resources.open_text(path, name) as fd:
-        return fd.read()
+    return importlib.resources.files(path).joinpath(name).read_text()
 
 
 def get_log_level() -> str:

--- a/tests/helpers/chat_interface.py
+++ b/tests/helpers/chat_interface.py
@@ -163,6 +163,13 @@ def make_interface(monkeypatch):
     monkeypatch.setattr(lair.sessions, "get_chat_session", lambda t: DummyChatSession())
     monkeypatch.setattr(lair.sessions, "SessionManager", SimpleSessionManager)
     monkeypatch.setattr(lair.reporting, "Reporting", DummyReporting)
+    import prompt_toolkit.application
+
+    monkeypatch.setattr(
+        prompt_toolkit.application,
+        "run_in_terminal",
+        lambda func, *args, **kwargs: func(),
+    )
 
     lair.config.set("chat.history_file", None)
 


### PR DESCRIPTION
## Summary
- avoid deprecated `open_text` usage
- stub `run_in_terminal` in tests so no deprecation warnings
- document warning fix

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf0788ea48320b86457a0a1e7e172