### PR TITLE
Reduce ruff complexity violations

### DIFF
--- a/lair/cli/chat_interface.py
+++ b/lair/cli/chat_interface.py
@@ -116,15 +116,20 @@ class ChatInterface(ChatInterfaceCommands, ChatInterfaceReports):
             logger.error(f"Unknown session: {id_or_alias}")
             sys.exit(1)
 
-        if not self.session_manager.is_alias_available(id_or_alias):
-            if isinstance(lair.util.safe_int(id_or_alias), int):
-                logger.error("Failed to create new session. Session aliases may not be integers.")
-            else:
-                logger.error("Failed to create new session. Alias is already used.")
-            sys.exit(1)
+        self._validate_new_session_alias(id_or_alias)
 
         self.chat_session.session_alias = id_or_alias
         self.session_manager.add_from_chat_session(self.chat_session)
+
+    def _validate_new_session_alias(self, alias: str | int) -> None:
+        """Ensure ``alias`` can be used for a new session."""
+        if self.session_manager.is_alias_available(alias):
+            return
+        if isinstance(lair.util.safe_int(alias), int):
+            logger.error("Failed to create new session. Session aliases may not be integers.")
+        else:
+            logger.error("Failed to create new session. Alias is already used.")
+        sys.exit(1)
 
     def _get_shortcut_details(self) -> dict[str, str]:
         """Return a mapping of shortcuts to descriptions."""

--- a/lair/cli/run.py
+++ b/lair/cli/run.py
@@ -120,23 +120,25 @@ def start() -> None:
     try:
         lair.logging.init_logging()
         arguments, subcommand = parse_arguments()
-
-        if arguments.debug:
-            logger.setLevel("DEBUG")
-
-        if arguments.mode:
-            lair.config.change_mode(arguments.mode)
-        set_config_from_arguments(arguments.set)
-        if arguments.model:
-            lair.config.set("model.name", arguments.model)
-
-        lair.reporting.Reporting(
-            disable_color=arguments.disable_color,
-            force_color=arguments.force_color,
-        )
-
+        _configure_from_args(arguments)
         subcommand.run(arguments)
     except KeyboardInterrupt:
         sys.exit("Received interrupt.  Exiting")
     except Exception as error:
         _handle_error(error, "arguments" in locals())
+
+
+def _configure_from_args(arguments: argparse.Namespace) -> None:
+    """Apply runtime options from the CLI arguments."""
+    if arguments.debug:
+        logger.setLevel("DEBUG")
+    if arguments.mode:
+        lair.config.change_mode(arguments.mode)
+    set_config_from_arguments(arguments.set)
+    if arguments.model:
+        lair.config.set("model.name", arguments.model)
+
+    lair.reporting.Reporting(
+        disable_color=arguments.disable_color,
+        force_color=arguments.force_color,
+    )

--- a/lair/components/tools/tmux_tool.py
+++ b/lair/components/tools/tmux_tool.py
@@ -131,14 +131,19 @@ class TmuxTool:
         if not window_id_str.startswith("@"):
             window_id_str = f"@{window_id_str}"
 
+        window = self._find_window(window_id_str)
+        if window is None:
+            raise ValueError(f"Requested window id not found: {window_id_str}")
+        return window
+
+    def _find_window(self, window_id_str: str) -> Window | None:
+        """Return the window matching ``window_id_str`` or ``None``."""
         if self.session is None:
             raise RuntimeError("No tmux session available.")
-
         for window in self.session.list_windows():
             if window.get("window_id") == window_id_str:
                 return window
-
-        raise ValueError(f"Requested window id not found: {window_id_str}")
+        return None
 
     def _ensure_connection(self) -> None:
         """Ensure a tmux server connection exists."""

--- a/lair/events.py
+++ b/lair/events.py
@@ -105,16 +105,24 @@ def fire(event_name: str, data: object | None = None) -> bool:
         data = {}
 
     if _deferring:
-        if not _should_squash(event_name, data):
-            _deferred_events.append((event_name, data))
+        _queue_event(event_name, data)
         return True
 
     logger.debug(f"events: fire(): {event_name}, data: {data}")
+    _dispatch(event_name, data)
+    return True
+
+
+def _queue_event(event_name: str, data: object) -> None:
+    if not _should_squash(event_name, data):
+        _deferred_events.append((event_name, data))
+
+
+def _dispatch(event_name: str, data: object) -> None:
     handlers = _event_handlers.get(event_name, set())
     for handler in list(handlers):  # Iterate over a copy to avoid modification issues
         if callable(handler):
             handler(data)
-    return True
 
 
 def _should_squash(event_name: str, data: object) -> bool:

--- a/lair/modules/comfy.py
+++ b/lair/modules/comfy.py
@@ -587,24 +587,28 @@ class Comfy:
             single_output: Whether ``results`` contains exactly one item.
 
         """
-        output_files = []
-
         if single_output:
-            if filename == "-":
-                sys.stdout.buffer.write(cast(bytes, results[0]) + b"\n")
-                return
-
-            self._save_output__save_to_disk(results[0], filename)
-            output_files.append(filename)
-            logger.debug(f"saved: {', '.join(output_files)}")
+            self._save_single_output(results[0], filename)
             return
 
+        self._save_multiple_outputs(results, filename, start_index)
+
+    def _save_single_output(self, item: object, filename: str) -> None:
+        if filename == "-":
+            sys.stdout.buffer.write(cast(bytes, item) + b"\n")
+            return
+
+        self._save_output__save_to_disk(item, filename)
+        logger.debug(f"saved: {filename}")
+
+    def _save_multiple_outputs(self, results: Sequence[object], filename: str, start_index: int) -> None:
         if filename == "-":
             raise Exception("Writing to STDOUT is only supported for single-file output")
         if not os.path.splitext(filename)[1]:
             raise ValueError("Filename must have an extension (e.g., 'output.png').")
 
         basename, extension = os.path.splitext(filename)
+        output_files = []
         for i, output in enumerate(results, start=start_index):
             padded_index = f"{i:06d}"  # Zero-padded to 6 digits
             output_filename = f"{basename}{padded_index}{extension}"


### PR DESCRIPTION
## Summary
- split session alias validation into helper
- add extraction argument parser and response output helpers
- move CLI argument processing into function
- split Python tool logic into smaller helpers
- factor window retrieval and alias validation helpers
- break configuration setter into helpers
- simplify event firing and queue logic
- refactor Comfy output saving helpers
- install dependencies for mypy

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cff265ff483209b42f6a965a6b344