### PR TITLE
Add listing for MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - comfy: Add `outpaint` workflow for extending images
 - comfy: Add `--denoise` option for outpainting
 - tools: Add MCP remote tool support and `/mcp-refresh` command
+- chat: Add `/list-mcp-tools` command and show MCP tools in `/list-tools`
 - docs: Document MCP tool usage in README
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The prompt and toolbar can be customized via `chat.*` settings.
 | /list-models     | Display a list of available models for the current session                                                              |
 | /list-settings   | Show and search settings  (for usage, run `/list-settings --help`)                                                      |
 | /list-tools      | Show tools and their status                                                                                             |
+| /list-mcp-tools  | Show tools discovered via MCP manifests                                                             |
 | /load            | Load a session from a file  (usage: `/load [filename?]`, default filename is `chat_session.json`)                       |
 | /messages        | Display or save the JSON message history as JSONL (usage: `/messages [filename?]`)                                      |
 | /mode            | Show or select a mode  (usage: `/mode [name?]`)                                                                         |
@@ -491,6 +492,7 @@ Each tool has its own configuration namespace and an individual `enabled` flag, 
 Tools are only compatible with models that support them. Attempting to use tools with unsupported models may result in errors or unpredictable behavior.
 
 The chat CLI provides the `/list-tools` command to display all available tools and their current status.
+Use `/list-mcp-tools` to see only tools loaded from MCP provider manifests.
 
 Tools can be quickly toggled on or off using the `ESC-T` shortcut.
 

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -40,6 +40,7 @@ class ChatInterfaceCommands:
     print_models_report: Callable[..., None]
     print_config_report: Callable[..., None]
     print_tools_report: Callable[..., None]
+    print_mcp_tools_report: Callable[..., None]
     _rebuild_chat_session: Callable[..., None]
     print_modes_report: Callable[..., None]
     print_current_model_report: Callable[..., None]
@@ -131,6 +132,12 @@ class ChatInterfaceCommands:
                     command, arguments, arguments_str
                 ),
                 "description": "Show tools and their status",
+            },
+            "/list-mcp-tools": {
+                "callback": lambda command, arguments, arguments_str: self.command_list_mcp_tools(
+                    command, arguments, arguments_str
+                ),
+                "description": "Show tools discovered via MCP manifests",
             },
             "/load": {
                 "callback": lambda command, arguments, arguments_str: self.command_load(
@@ -539,6 +546,18 @@ class ChatInterfaceCommands:
             self.reporting.user_error("ERROR: /list-tools takes no arguments")
         else:
             self.print_tools_report()
+
+    def command_list_mcp_tools(
+        self,
+        command: str,
+        arguments: list[str],
+        arguments_str: str,
+    ) -> None:
+        """Display tools discovered via MCP manifests."""
+        if len(arguments) != 0:
+            self.reporting.user_error("ERROR: /list-mcp-tools takes no arguments")
+        else:
+            self.print_mcp_tools_report()
 
     def command_load(
         self,

--- a/lair/cli/chat_interface_reports.py
+++ b/lair/cli/chat_interface_reports.py
@@ -196,3 +196,18 @@ class ChatInterfaceReports:
         self.reporting.table_from_dicts_system(
             tools, column_names=["class_name", "name", "enabled"], column_formatters=column_formatters
         )
+
+    def print_mcp_tools_report(self) -> None:
+        """Display tools loaded from MCP manifests."""
+        tools = [tool for tool in self.chat_session.tool_set.get_all_tools() if tool["class_name"] == "MCPTool"]
+        if not tools:
+            self.reporting.system_message("No MCP tools found.")
+            return
+        column_formatters = {
+            "enabled": lambda v: self.reporting.color_bool(v, true_str="yes", false_str="-", false_style="dim"),
+        }
+        self.reporting.table_from_dicts_system(
+            sorted(tools, key=lambda m: m["name"]),
+            column_names=["name", "enabled", "source"],
+            column_formatters=column_formatters,
+        )

--- a/lair/components/tools/mcp_tool.py
+++ b/lair/components/tools/mcp_tool.py
@@ -51,6 +51,7 @@ class MCPTool:
                 flags=["tools.mcp.enabled"],
                 definition=tool_def,
                 handler=self._make_handler(base_url, name),
+                metadata={"source": base_url},
             )
 
     def _make_handler(self, base_url: str, name: str) -> Callable[..., dict[str, Any]]:

--- a/lair/components/tools/tool_set.py
+++ b/lair/components/tools/tool_set.py
@@ -66,6 +66,7 @@ class ToolSet:
         definition_handler: Callable[[], dict[str, Any]] | None = None,
         handler: Callable[..., dict[str, Any]],
         class_name: str,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """
         Register a new tool in the collection.
@@ -78,6 +79,7 @@ class ToolSet:
                 Takes precedence over ``definition`` when provided.
             handler: Callable executed when the tool is invoked.
             class_name: Name of the implementing class.
+            metadata: Optional metadata to associate with the tool.
 
         Raises:
             ValueError: If a tool with the same name already exists or if both
@@ -97,6 +99,8 @@ class ToolSet:
             "handler": handler,
             "name": name,
         }
+        if metadata:
+            self.tools[name].update(metadata)
 
     def get_tools(self) -> list[dict[str, Any]]:
         """Return tools that are currently enabled."""
@@ -120,6 +124,8 @@ class ToolSet:
 
     def get_all_tools(self) -> list[dict[str, Any]] | None:
         """Return metadata for all tools with an ``enabled`` field."""
+        if self.mcp_tool:
+            self.mcp_tool.ensure_manifest()
         all_tools = []
         for tool in self.tools.values():
             tool["enabled"] = lair.config.get("tools.enabled") and self.all_flags_enabled(tool["flags"]) is True

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -18,6 +18,7 @@ def setup_ci(monkeypatch):
     monkeypatch.setattr(ci.chat_session, "save_to_file", lambda *a, **k: None)
     monkeypatch.setattr(ci.chat_session.tool_set, "get_all_tools", lambda: [])
     monkeypatch.setattr(ci, "print_tools_report", lambda *a, **k: None)
+    monkeypatch.setattr(ci, "print_mcp_tools_report", lambda *a, **k: None)
     monkeypatch.setattr(ci, "print_models_report", lambda *a, **k: None)
     monkeypatch.setattr(ci, "print_config_report", lambda *a, **k: None)
     monkeypatch.setattr(ci, "print_history", lambda *a, **k: None)
@@ -51,6 +52,7 @@ COMMANDS = [
     ("list_models", [], ["a"]),
     ("list_settings", [], ["--bad"]),
     ("list_tools", [], ["a"]),
+    ("list_mcp_tools", [], ["a"]),
     ("load", [], None),
     ("messages", [], ["file1", "file2"]),
     ("mode", ["openai"], ["a", "b"]),

--- a/tests/unit/test_chat_interface_reports.py
+++ b/tests/unit/test_chat_interface_reports.py
@@ -107,6 +107,16 @@ def test_models_and_modes_and_tools_reports():
     assert len(ci.reporting.tables) == 3
 
 
+def test_print_mcp_tools_report():
+    tools = [
+        {"class_name": "MCPTool", "name": "a", "enabled": True, "source": "s"},
+        {"class_name": "FileTool", "name": "b", "enabled": False},
+    ]
+    ci = make_ci(tools=tools)
+    ci.print_mcp_tools_report()
+    assert ci.reporting.tables and ci.reporting.tables[0][1][0]["name"] == "a"
+
+
 def test_print_sessions_report():
     sessions = [
         {"id": 1, "alias": "a", "title": "t1", "session": {"mode": "m1", "model_name": "m"}, "history": [1]},


### PR DESCRIPTION
## Summary
- include MCP tools in /list-tools output
- add `/list-mcp-tools` command to show tools from MCP manifests
- track provider URL for each MCP tool
- update docs and changelog
- test MCP tool listing and new command

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68804347b14c83209eb7f0f32a295e5e