### PR TITLE
Improve MCP compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - cli: Ensure `/mcp-refresh` reloads manifests and `/list-mcp-tools` fetches missing manifests
 - cli: Show MCP status in `/list-tools`
 - mcp: Load manifests via JSON-RPC and avoid refreshing when tools are disabled
+- mcp: Support initialization handshake, SSE responses, and pagination
 - tests: Increase coverage for chat interface reports
 - comfyscript: Restart watch thread correctly
 - comfy: Raise ValueError for invalid image path type


### PR DESCRIPTION
## Summary
- handle initialization handshake and SSE in MCP tool
- support pagination for MCP `tools/list`
- test MCP tool compliance with SSE and handshake
- update change log

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d596c3a083209efb1639aa4d963a