### PR TITLE
Fix MCP initialization handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - tests: Stub prompt_toolkit run_in_terminal to remove warnings
 - tests: Support environments where `openai_local` mode is renamed
 - cli: Fix session alias prompt so pressing enter keeps or removes the alias
+- mcp: Send `initialized` notification for spec compliance
 
 ### New Features
 - comfy: Add `outpaint` workflow for extending images

--- a/lair/components/tools/mcp_tool.py
+++ b/lair/components/tools/mcp_tool.py
@@ -90,7 +90,7 @@ class MCPTool:
             self._parse_body(response)
             requests.post(
                 base_url,
-                json={"jsonrpc": JSONRPC_VERSION, "method": "notifications/initialized", "params": {}},
+                json={"jsonrpc": JSONRPC_VERSION, "method": "initialized", "params": {}},
                 headers=ACCEPT_HEADER,
                 timeout=timeout,
             ).raise_for_status()

--- a/tests/unit/test_mcp_tool.py
+++ b/tests/unit/test_mcp_tool.py
@@ -103,7 +103,7 @@ def test_manifest_sse_and_handshake(monkeypatch):
 
     def fake_post(url, json=None, headers=None, timeout=None):
         calls.append((json["method"], headers))
-        if json["method"] in {"initialize", "notifications/initialized"}:
+        if json["method"] in {"initialize", "initialized"}:
             return _json_response({})
         if json["method"] == "tools/list":
             data = page2 if json.get("params", {}).get("cursor") else page1
@@ -140,7 +140,7 @@ def test_get_all_tools_loads_manifest(monkeypatch):
     def fake_post(url, json, timeout, headers=None):
         if json["method"] == "tools/list":
             return _json_response(manifest)
-        if json["method"] in {"initialize", "notifications/initialized"}:
+        if json["method"] in {"initialize", "initialized"}:
             return _json_response({})
         return _json_response({})
 


### PR DESCRIPTION
## Summary
- send `initialized` notification instead of `notifications/initialized`
- update tests for MCP handshake
- document in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dd77afec8320a1b30f03efbad4df