### PR TITLE
Fix MCP tool manifest parsing and refresh summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - tests: Support environments where `openai_local` mode is renamed
 - cli: Fix session alias prompt so pressing enter keeps or removes the alias
 - mcp: Send `initialized` notification for spec compliance
+- mcp: Handle simplified manifest format and report tool counts from `/mcp-refresh`
 
 ### New Features
 - comfy: Add `outpaint` workflow for extending images

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -676,7 +676,9 @@ class ChatInterfaceCommands:
             self.reporting.user_error("ERROR: MCP tool is not available")
             return
         mcp_tool.refresh()
-        mcp_tool.ensure_manifest()
+        counts = mcp_tool.ensure_manifest() or {}
+        for url, count in counts.items():
+            self.reporting.system_message(f"Loaded {count} tool{'s' if count != 1 else ''} from {url}")
         self.reporting.system_message("MCP manifest refreshed")
 
     def command_save(

--- a/tests/unit/test_mcp_refresh.py
+++ b/tests/unit/test_mcp_refresh.py
@@ -53,3 +53,4 @@ def test_mcp_refresh_loads_manifest(monkeypatch):
     ci.command_mcp_refresh("/mcp-refresh", [], "")
     assert "echo" in ci.chat_session.tool_set.tools
     assert call_count["post"] == 3
+    assert ("system", "Loaded 1 tool from http://server") in ci.reporting.messages


### PR DESCRIPTION
## Summary
- handle simplified MCP manifest formats and track load counts
- show loaded tool counts from each MCP server in `/mcp-refresh`
- update tests for MCP manifest support and new summary line
- document change in CHANGELOG

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `poetry run mypy lair`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881597b276c8320b9416f0ec2cd4e53