### PR TITLE
Support plain format for MCP tool manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - tests: Support environments where `openai_local` mode is renamed
 - cli: Fix session alias prompt so pressing enter keeps or removes the alias
 - mcp: Send `initialized` notification for spec compliance
+- mcp: Support tool manifests with `name` and `input_schema` fields
 
 ### New Features
 - comfy: Add `outpaint` workflow for extending images


### PR DESCRIPTION
## Summary
- support `name`/`input_schema` tool definitions in MCPTool
- test MCPTool with this plain manifest format
- document fix in changelog

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair tests`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881693813808320a9d679f177dc0d96