### PR TITLE
Sanitize MCP tool names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - mcp: Send `initialized` notification for spec compliance
 - mcp: Support tool manifests with `name` and `input_schema` fields
 - mcp: Skip loading tools with invalid names
+- mcp: Sanitize tool names and rename `crt.sh` alias to `crtsh`
 
 ### New Features
 - comfy: Add `outpaint` workflow for extending images


### PR DESCRIPTION
## Summary
- sanitize MCP tool names
- rename crt.sh alias to crtsh
- update tests for sanitized names

## Testing
- `python -m compileall -q lair`
- `ruff check lair`
- `ruff format lair`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818f47d81c8320a102e87435d0041f