### PR TITLE
Add summary output for /mcp-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - tools: Add MCP remote tool support and `/mcp-refresh` command
 - chat: Add `/list-mcp-tools` command and show MCP tools in `/list-tools`
 - docs: Document MCP tool usage in README
+- cli: Show per-provider summary after `/mcp-refresh`
 
 ### Internal
 - documentation: Add AGENTS.md and introduction video link

--- a/README.md
+++ b/README.md
@@ -625,7 +625,9 @@ like built-in tools.
 MCP tools are disabled by default. To enable them, set ``tools.enabled`` and
 ``tools.mcp.enabled`` to ``true``. Provider URLs are specified one per line in
 ``tools.mcp.providers``. If changes are made on the provider side, run the
-``/mcp-refresh`` command in the chat interface to reload the manifest.
+``/mcp-refresh`` command in the chat interface to reload the manifest. The
+refresh output lists each provider URL with the number of tools found or
+displays a warning when none are available.
 
 The timeout for both manifest requests and tool calls is controlled by
 ``tools.mcp.timeout`` and defaults to ``10`` seconds.

--- a/lair/cli/chat_interface_commands.py
+++ b/lair/cli/chat_interface_commands.py
@@ -678,6 +678,23 @@ class ChatInterfaceCommands:
         mcp_tool.refresh()
         mcp_tool.ensure_manifest()
         self.reporting.system_message("MCP manifest refreshed")
+        self._report_mcp_summary(mcp_tool.get_manifest_summary())
+
+    def _report_mcp_summary(self, summary: dict[str, int] | None) -> None:
+        """Display MCP refresh summary lines."""
+        summary = summary or {}
+        if not summary:
+            self.reporting.user_warning("No MCP providers configured")
+            return
+        any_tools = any(count > 0 for count in summary.values())
+        for url, count in summary.items():
+            message = f"{url} - {count} tool{'s' if count != 1 else ''}"
+            if count > 0:
+                self.reporting.system_message(message)
+            else:
+                self.reporting.user_warning(message)
+        if not any_tools:
+            self.reporting.user_warning("No tools found")
 
     def command_save(
         self,

--- a/lair/files/settings.yaml
+++ b/lair/files/settings.yaml
@@ -343,6 +343,7 @@ style.tool_message.response_syntax_highlighting: true
 style.tool_message.background: '#021f00'
 
 style.user_error: 'dim red'
+style.user_warning: 'yellow'
 # Whether or not output should word-wrap, or be written as-is
 style.word_wrap: true
 

--- a/lair/reporting/reporting.py
+++ b/lair/reporting/reporting.py
@@ -380,6 +380,10 @@ class Reporting(metaclass=ReportingSingletoneMeta):
         """Display a user-facing error message."""
         self.print_rich(self.style(message), style=str(lair.config.get("style.user_error")))
 
+    def user_warning(self, message: str) -> None:
+        """Display a user-facing warning message."""
+        self.print_rich(self.style(message), style=str(lair.config.get("style.user_warning")))
+
     def system_message(
         self,
         message: str,

--- a/tests/helpers/chat_interface.py
+++ b/tests/helpers/chat_interface.py
@@ -53,6 +53,9 @@ class DummyReporting:
     def user_error(self, message) -> None:
         self.messages.append(("error", message))
 
+    def user_warning(self, message) -> None:
+        self.messages.append(("warning", message))
+
     def print_rich(self, *args, **kwargs) -> None:  # pragma: no cover - stub
         pass
 

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -24,7 +24,11 @@ def setup_ci(monkeypatch):
     monkeypatch.setattr(ci, "print_history", lambda *a, **k: None)
     monkeypatch.setattr(ci, "print_help", lambda *a, **k: None)
     monkeypatch.setattr(ci, "_rebuild_chat_session", lambda *a, **k: None)
-    ci.chat_session.tool_set.mcp_tool = types.SimpleNamespace(refresh=lambda: None, ensure_manifest=lambda: None)
+    ci.chat_session.tool_set.mcp_tool = types.SimpleNamespace(
+        refresh=lambda: None,
+        ensure_manifest=lambda: None,
+        get_manifest_summary=lambda: {},
+    )
     orig_get = ci.session_manager.get_session_id
 
     def patched_get(id_or_alias, raise_exception=True):

--- a/tests/unit/test_mcp_refresh.py
+++ b/tests/unit/test_mcp_refresh.py
@@ -53,3 +53,54 @@ def test_mcp_refresh_loads_manifest(monkeypatch):
     ci.command_mcp_refresh("/mcp-refresh", [], "")
     assert "echo" in ci.chat_session.tool_set.tools
     assert call_count["post"] == 3
+    assert ("system", "MCP manifest refreshed") in ci.reporting.messages
+    assert ("system", "http://server - 1 tool") in ci.reporting.messages
+
+
+def test_mcp_refresh_no_providers(monkeypatch):
+    ci = make_interface(monkeypatch)
+    tool = MCPTool()
+    tool.add_to_tool_set(ci.chat_session.tool_set)
+    ci.chat_session.tool_set.mcp_tool = tool
+    lair.config.set("tools.enabled", True, no_event=True)
+    lair.config.set("tools.mcp.enabled", True, no_event=True)
+    lair.config.set("tools.mcp.providers", "", no_event=True)
+
+    ci.command_mcp_refresh("/mcp-refresh", [], "")
+    assert ("warning", "No MCP providers configured") in ci.reporting.messages
+
+
+def test_mcp_refresh_no_tools(monkeypatch):
+    ci = make_interface(monkeypatch)
+    tool = MCPTool()
+    tool.add_to_tool_set(ci.chat_session.tool_set)
+    ci.chat_session.tool_set.mcp_tool = tool
+    lair.config.set("tools.enabled", True, no_event=True)
+    lair.config.set("tools.mcp.enabled", True, no_event=True)
+    lair.config.set("tools.mcp.providers", "http://server", no_event=True)
+    lair.config.set("tools.mcp.timeout", 5.0, no_event=True)
+
+    manifest = {"tools": []}
+
+    monkeypatch.setattr(MCPTool, "_get_providers", lambda self: ["http://server"])
+
+    def fake_post(url, json, timeout, headers=None):
+        if json["method"] == "tools/list":
+            return SimpleNamespace(
+                status_code=200,
+                headers={"Content-Type": "application/json"},
+                json=lambda: {"result": manifest},
+                raise_for_status=lambda: None,
+            )
+        return SimpleNamespace(
+            status_code=200,
+            headers={"Content-Type": "application/json"},
+            json=lambda: {"result": {}},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(lair.components.tools.mcp_tool, "requests", SimpleNamespace(post=fake_post))
+
+    ci.command_mcp_refresh("/mcp-refresh", [], "")
+    assert ("warning", "http://server - 0 tools") in ci.reporting.messages
+    assert ("warning", "No tools found") in ci.reporting.messages


### PR DESCRIPTION
## Summary
- display number of tools found per provider when `/mcp-refresh` runs
- warn when no providers or tools are found
- style warnings with new `style.user_warning` setting
- expose manifest summary via `MCPTool.get_manifest_summary`
- update docs, changelog, and tests

## Testing
- `python -m compileall -q lair`
- `ruff check lair tests`
- `ruff format lair tests --silent`
- `mypy lair`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822e1a7bfc83208ed94a152e5ee277